### PR TITLE
feat: onboarding & safety overhaul — replayable welcome, 4 teaching silos, confirm+undo, fresh-install auto-config

### DIFF
--- a/scripts/copy-static.mjs
+++ b/scripts/copy-static.mjs
@@ -11,6 +11,7 @@ mkdirSync(outputDir, { recursive: true });
 mkdirSync(resolve(outputDir, "background"), { recursive: true });
 mkdirSync(resolve(outputDir, "content_scripts"), { recursive: true });
 mkdirSync(resolve(outputDir, "popup"), { recursive: true });
+mkdirSync(resolve(outputDir, "welcome"), { recursive: true });
 mkdirSync(resolve(outputDir, "assets"), { recursive: true });
 
 // copy manifest.json (root -> dist)
@@ -24,6 +25,10 @@ try { copyFileSync(resolve(root, "src/popup/popup.css"), resolve(outputDir, "pop
 
 // copy error-guard.js (CSP-safe global error handler, must load before popup.js)
 try { copyFileSync(resolve(root, "src/popup/error-guard.js"), resolve(outputDir, "popup/error-guard.js")); } catch(e) { /* ignore */ }
+
+// copy welcome / onboarding page (html + css; welcome.js is bundled by esbuild)
+try { copyFileSync(resolve(root, "src/welcome/welcome.html"), resolve(outputDir, "welcome/welcome.html")); } catch(e) { /* ignore */ }
+try { copyFileSync(resolve(root, "src/welcome/welcome.css"), resolve(outputDir, "welcome/welcome.css")); } catch(e) { /* ignore */ }
 
 // copy assets
 try {

--- a/scripts/esbuild-dev.mjs
+++ b/scripts/esbuild-dev.mjs
@@ -52,6 +52,14 @@ const common = {
       format: "iife"
     });
 
+    // welcome / onboarding page
+    await build({
+      ...common,
+      entryPoints: [resolve(cwd, "src/welcome/welcome.ts")],
+      outfile: resolve(outdir, "welcome/welcome.js"),
+      format: "iife"
+    });
+
     console.log("esbuild-dev: Bundles written to dist/");
   } catch (err) {
     console.error("esbuild-dev error:", err);

--- a/scripts/esbuild-prod.mjs
+++ b/scripts/esbuild-prod.mjs
@@ -65,6 +65,15 @@ const common = {
     });
     results.push({ name: "popup", result: popupResult });
 
+    // welcome / onboarding page (lazy — only loads when the welcome tab is open)
+    const welcomeResult = await build({
+      ...common,
+      entryPoints: [resolve(cwd, "src/welcome/welcome.ts")],
+      outfile: resolve(outdir, "welcome/welcome.js"),
+      format: "iife"
+    });
+    results.push({ name: "welcome", result: welcomeResult });
+
     console.log("\n✅ esbuild-prod: Bundles written to dist/");
     
     // Bundle size analysis

--- a/src/__test-utils__/settings-mock.ts
+++ b/src/__test-utils__/settings-mock.ts
@@ -34,6 +34,12 @@ const DEFAULT_SETTINGS: Record<string, unknown> = {
   commandPaletteEnabled: true,
   webSearchEngine: 'google',
   developerGithubPat: '',
+  onboardingEnabled: true,
+  onboardingChecklistEnabled: true,
+  onboardingTipsEnabled: true,
+  onboardingCheatsheetEnabled: true,
+  onboardingDemosEnabled: true,
+  welcomeShownVersion: '',
 };
 
 /**

--- a/src/__test-utils__/settings-mock.ts
+++ b/src/__test-utils__/settings-mock.ts
@@ -56,6 +56,7 @@ export function mockSettings(overrides: Record<string, unknown> = {}) {
       setSetting: vi.fn(),
       updateSettings: vi.fn(),
       applyRemoteSettings: vi.fn(),
+      reloadFromStorage: vi.fn().mockResolvedValue(undefined),
     },
     SETTINGS_SCHEMA: {},
     DisplayMode: { List: 'list', Card: 'card' },

--- a/src/background/handlers/__tests__/settings-handlers.test.ts
+++ b/src/background/handlers/__tests__/settings-handlers.test.ts
@@ -109,6 +109,7 @@ describe('registerSettingsHandlers', () => {
     expect(preInit.registeredTypes).toEqual(expect.arrayContaining([
       'PING',
       'OPEN_SETTINGS',
+      'OPEN_WELCOME',
       'GET_LOG_LEVEL',
       'SET_LOG_LEVEL',
       'SETTINGS_CHANGED',
@@ -181,6 +182,26 @@ describe('registerSettingsHandlers', () => {
     it('accepts a non-Error rejection via the String(err) fallback in the .catch', async () => {
       helperMocks.tabsCreate.mockRejectedValueOnce('plain-string-error');
       const res = await dispatch(preInit, { type: 'OPEN_SETTINGS' });
+      expect(res).toEqual({ status: 'ok' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
+  describe('OPEN_WELCOME', () => {
+    it('responds ok and requests the welcome page URL', async () => {
+      const res = await dispatch(preInit, { type: 'OPEN_WELCOME' });
+
+      expect(res).toEqual({ status: 'ok' });
+      expect(helperMocks.runtimeGetURL).toHaveBeenCalledWith('welcome/welcome.html');
+      expect(helperMocks.tabsCreate).toHaveBeenCalledWith({
+        url: 'chrome-extension://mock/welcome/welcome.html',
+      });
+    });
+
+    it('suppresses tabs.create rejection via .catch branch without rejecting the handler', async () => {
+      helperMocks.tabsCreate.mockRejectedValueOnce(new Error('tab create fail'));
+      const res = await dispatch(preInit, { type: 'OPEN_WELCOME' });
       expect(res).toEqual({ status: 'ok' });
       await Promise.resolve();
       await Promise.resolve();

--- a/src/background/handlers/settings-handlers.ts
+++ b/src/background/handlers/settings-handlers.ts
@@ -28,6 +28,17 @@ export function registerSettingsHandlers(
     sendResponse({ status: 'ok' });
   });
 
+  preInit.register('OPEN_WELCOME', async (_msg, _sender, sendResponse) => {
+    log.debug('OPEN_WELCOME', 'Handling OPEN_WELCOME');
+    void browserAPI.tabs
+      .create({ url: browserAPI.runtime.getURL('welcome/welcome.html') })
+      .catch(
+        (err: unknown) =>
+          log.error('OPEN_WELCOME', 'Failed to open welcome tab', errorMeta(err)),
+      );
+    sendResponse({ status: 'ok' });
+  });
+
   preInit.register('GET_LOG_LEVEL', async (_msg, _sender, sendResponse) => {
     sendResponse({ logLevel: Logger.getLevel() });
   });

--- a/src/background/lifecycle/__tests__/fresh-install.test.ts
+++ b/src/background/lifecycle/__tests__/fresh-install.test.ts
@@ -2,8 +2,14 @@ import { describe, it, expect, vi } from 'vitest';
 import { applyFreshInstallProfile, type SettingsWriter } from '../fresh-install';
 import { FRESH_INSTALL_PROFILE } from '../../../core/fresh-install-profile';
 
-function makeWriter(): SettingsWriter & { updateSettings: ReturnType<typeof vi.fn> } {
-  return { updateSettings: vi.fn().mockResolvedValue(undefined) };
+function makeWriter(): SettingsWriter & {
+  updateSettings: ReturnType<typeof vi.fn>;
+  reloadFromStorage: ReturnType<typeof vi.fn>;
+} {
+  return {
+    reloadFromStorage: vi.fn().mockResolvedValue(undefined),
+    updateSettings: vi.fn().mockResolvedValue(undefined),
+  };
 }
 
 describe('applyFreshInstallProfile', () => {
@@ -14,6 +20,18 @@ describe('applyFreshInstallProfile', () => {
     expect(applied).toBe(true);
     expect(writer.updateSettings).toHaveBeenCalledTimes(1);
     expect(writer.updateSettings).toHaveBeenCalledWith(FRESH_INSTALL_PROFILE);
+  });
+
+  it('reloads from storage BEFORE writing (so the profile never clobbers a concurrent write)', async () => {
+    const order: string[] = [];
+    const writer: SettingsWriter = {
+      reloadFromStorage: vi.fn(async () => { order.push('reload'); }),
+      updateSettings: vi.fn(async () => { order.push('write'); }),
+    };
+
+    await applyFreshInstallProfile('install', writer);
+
+    expect(order).toEqual(['reload', 'write']);
   });
 
   it.each(['update', 'chrome_update', 'shared_module_update'] as const)(
@@ -28,7 +46,10 @@ describe('applyFreshInstallProfile', () => {
   );
 
   it('is non-fatal: returns false when the writer throws', async () => {
-    const writer = { updateSettings: vi.fn().mockRejectedValue(new Error('storage down')) };
+    const writer: SettingsWriter = {
+      reloadFromStorage: vi.fn().mockResolvedValue(undefined),
+      updateSettings: vi.fn().mockRejectedValue(new Error('storage down')),
+    };
     const applied = await applyFreshInstallProfile('install', writer);
 
     expect(applied).toBe(false);

--- a/src/background/lifecycle/__tests__/fresh-install.test.ts
+++ b/src/background/lifecycle/__tests__/fresh-install.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { applyFreshInstallProfile, type SettingsWriter } from '../fresh-install';
+import { FRESH_INSTALL_PROFILE } from '../../../core/fresh-install-profile';
+
+function makeWriter(): SettingsWriter & { updateSettings: ReturnType<typeof vi.fn> } {
+  return { updateSettings: vi.fn().mockResolvedValue(undefined) };
+}
+
+describe('applyFreshInstallProfile', () => {
+  it('applies the profile exactly once on a fresh install', async () => {
+    const writer = makeWriter();
+    const applied = await applyFreshInstallProfile('install', writer);
+
+    expect(applied).toBe(true);
+    expect(writer.updateSettings).toHaveBeenCalledTimes(1);
+    expect(writer.updateSettings).toHaveBeenCalledWith(FRESH_INSTALL_PROFILE);
+  });
+
+  it.each(['update', 'chrome_update', 'shared_module_update'] as const)(
+    'does NOT touch settings on reason "%s" (existing users preserved)',
+    async (reason) => {
+      const writer = makeWriter();
+      const applied = await applyFreshInstallProfile(reason, writer);
+
+      expect(applied).toBe(false);
+      expect(writer.updateSettings).not.toHaveBeenCalled();
+    },
+  );
+
+  it('is non-fatal: returns false when the writer throws', async () => {
+    const writer = { updateSettings: vi.fn().mockRejectedValue(new Error('storage down')) };
+    const applied = await applyFreshInstallProfile('install', writer);
+
+    expect(applied).toBe(false);
+    expect(writer.updateSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/background/lifecycle/fresh-install.ts
+++ b/src/background/lifecycle/fresh-install.ts
@@ -10,8 +10,9 @@ import { Logger, errorMeta } from '../../core/logger';
 
 const log = Logger.forComponent('FreshInstall');
 
-/** Minimal port: anything that can persist a settings overlay. */
+/** Minimal port: re-sync from storage, then persist a settings overlay. */
 export interface SettingsWriter {
+  reloadFromStorage(): Promise<void>;
   updateSettings(updates: Partial<AppSettings>): Promise<void>;
 }
 
@@ -30,6 +31,12 @@ export async function applyFreshInstallProfile(
     return false; // upgrades & module updates: never touch existing settings
   }
   try {
+    // Re-sync from storage first so the profile merges OVER the latest persisted
+    // settings. This prevents the whole-object save in updateSettings from
+    // clobbering a value another context wrote during startup (the profile only
+    // overrides schema defaults — it never reverts a concurrently-persisted setting
+    // that isn't part of the profile).
+    await writer.reloadFromStorage();
     await writer.updateSettings(FRESH_INSTALL_PROFILE);
     log.info('applyFreshInstallProfile', '🎁 Fresh-install profile applied', {
       keys: Object.keys(FRESH_INSTALL_PROFILE).length,

--- a/src/background/lifecycle/fresh-install.ts
+++ b/src/background/lifecycle/fresh-install.ts
@@ -1,0 +1,43 @@
+// fresh-install.ts — applies FRESH_INSTALL_PROFILE exactly once, on a brand-new install.
+//
+// Kept tiny and dependency-injected so it is trivially unit-testable without the
+// service-worker boot chain. See core/fresh-install-profile.ts for the policy.
+
+import type { AppSettings } from '../../core/settings';
+import { SettingsManager } from '../../core/settings';
+import { FRESH_INSTALL_PROFILE } from '../../core/fresh-install-profile';
+import { Logger, errorMeta } from '../../core/logger';
+
+const log = Logger.forComponent('FreshInstall');
+
+/** Minimal port: anything that can persist a settings overlay. */
+export interface SettingsWriter {
+  updateSettings(updates: Partial<AppSettings>): Promise<void>;
+}
+
+/**
+ * Apply the opinionated fresh-install profile — but ONLY on a true first install.
+ * Upgrades (reason 'update' / 'chrome_update' / 'shared_module_update') are left
+ * untouched so existing users keep their chosen settings.
+ *
+ * @returns true if the profile was applied, false if skipped (not a fresh install).
+ */
+export async function applyFreshInstallProfile(
+  reason: chrome.runtime.OnInstalledReason,
+  writer: SettingsWriter = SettingsManager,
+): Promise<boolean> {
+  if (reason !== 'install') {
+    return false; // upgrades & module updates: never touch existing settings
+  }
+  try {
+    await writer.updateSettings(FRESH_INSTALL_PROFILE);
+    log.info('applyFreshInstallProfile', '🎁 Fresh-install profile applied', {
+      keys: Object.keys(FRESH_INSTALL_PROFILE).length,
+    });
+    return true;
+  } catch (err) {
+    // Non-fatal: a brand-new user simply falls back to the schema baseline defaults.
+    log.warn('applyFreshInstallProfile', 'Failed to apply fresh-install profile', errorMeta(err));
+    return false;
+  }
+}

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -16,6 +16,7 @@ import { registerCommandsListenerEarly, keepServiceWorkerAlive, reinjectContentS
 import { setupPortBasedMessaging, broadcastToActivePorts } from './lifecycle/port-messaging';
 import { setupDataChangeListeners, type DataChangeSource } from './lifecycle/data-change-listeners';
 import { setupOmnibox } from './lifecycle/omnibox';
+import { applyFreshInstallProfile } from './lifecycle/fresh-install';
 
 let initialized = false;
 let initializationPromise: Promise<void> | null = null;
@@ -270,6 +271,10 @@ browserAPI.runtime.onInstalled.addListener(async (details) => {
   try {
     logger.info('onInstalled', `📦 Extension ${details.reason}: v${chrome.runtime.getManifest().version}`);
     if (!initialized) {await init();}
+    // Apply the opinionated "fully set-up gift" on a brand-new install only.
+    // No-op on upgrades — existing users keep their settings. (Phase 2 will also
+    // open the welcome page here when reason === 'install'.)
+    await applyFreshInstallProfile(details.reason);
     if (details.reason === 'update' || details.reason === 'install') {
       try {
         const tabs = await browserAPI.tabs.query({ url: ['http://*/*', 'https://*/*'] });

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -272,9 +272,18 @@ browserAPI.runtime.onInstalled.addListener(async (details) => {
     logger.info('onInstalled', `📦 Extension ${details.reason}: v${chrome.runtime.getManifest().version}`);
     if (!initialized) {await init();}
     // Apply the opinionated "fully set-up gift" on a brand-new install only.
-    // No-op on upgrades — existing users keep their settings. (Phase 2 will also
-    // open the welcome page here when reason === 'install'.)
+    // No-op on upgrades — existing users keep their settings.
     await applyFreshInstallProfile(details.reason);
+    // Greet brand-new users with the replayable welcome page (unless onboarding is
+    // disabled). Fire-and-forget — never block boot. No extra permission: this is an
+    // extension-internal page opened via chrome.tabs.create.
+    if (details.reason === 'install' && SettingsManager.getSetting('onboardingEnabled') !== false) {
+      const version = chrome.runtime.getManifest().version;
+      void browserAPI.tabs
+        .create({ url: browserAPI.runtime.getURL('welcome/welcome.html') })
+        .then(() => SettingsManager.setSetting('welcomeShownVersion', version))
+        .catch((e) => logger.warn('onInstalled', 'Welcome page open failed', errorMeta(e)));
+    }
     if (details.reason === 'update' || details.reason === 'install') {
       try {
         const tabs = await browserAPI.tabs.query({ url: ['http://*/*', 'https://*/*'] });

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -270,7 +270,12 @@ setupIdleWakeListener(
 browserAPI.runtime.onInstalled.addListener(async (details) => {
   try {
     logger.info('onInstalled', `📦 Extension ${details.reason}: v${chrome.runtime.getManifest().version}`);
-    if (!initialized) {await init();}
+    // Settings/onboarding work runs FIRST — it's fast and must land before the slow
+    // DB+history init() below. Doing it early means a brand-new install's profile is
+    // applied within milliseconds of load, so it can't race a settings write that
+    // arrives during init's multi-second indexing pass. SettingsManager.init() is
+    // idempotent (cached) and only reads storage.
+    await SettingsManager.init();
     // Apply the opinionated "fully set-up gift" on a brand-new install only.
     // No-op on upgrades — existing users keep their settings.
     await applyFreshInstallProfile(details.reason);
@@ -284,6 +289,8 @@ browserAPI.runtime.onInstalled.addListener(async (details) => {
         .then(() => SettingsManager.setSetting('welcomeShownVersion', version))
         .catch((e) => logger.warn('onInstalled', 'Welcome page open failed', errorMeta(e)));
     }
+    // Now the heavy initialization (DB open + history ingest).
+    if (!initialized) {await init();}
     if (details.reason === 'update' || details.reason === 'install') {
       try {
         const tabs = await browserAPI.tabs.query({ url: ['http://*/*', 'https://*/*'] });

--- a/src/content_scripts/quick-search.ts
+++ b/src/content_scripts/quick-search.ts
@@ -74,6 +74,7 @@ import {
   PALETTE_DIAGNOSTIC_TOAST_MS,
 } from '../shared/palette-messages';
 import { wireHideImgOnError } from '../shared/hide-img-on-error';
+import { markMilestone, type MilestoneId } from '../shared/onboarding/milestones';
 import {
   type PaletteMode,
   type PaletteRowAttrs,
@@ -94,6 +95,15 @@ import {
   resolvePaletteCopyTarget,
   decideBfcacheAction,
 } from './quick-search-utils';
+
+// Onboarding milestones (Silo A): mark once per page so we never hit chrome.storage
+// repeatedly. markMilestone is itself idempotent; this just avoids redundant reads.
+const _markedMilestones = new Set<MilestoneId>();
+function markMilestoneOnce(id: MilestoneId): void {
+  if (_markedMilestones.has(id)) { return; }
+  _markedMilestones.add(id);
+  void markMilestone(id);
+}
 
 // Extend window interface for our extension
 declare global {
@@ -2232,6 +2242,8 @@ if (!window.__SMRUTI_QUICK_SEARCH_LOADED__) {
     const t0 = performance.now();
     log.debug('overlay', 'showOverlay called');
 
+    markMilestoneOnce('firstOverlayOpen');
+
     if (!shadowHost) {
       const t1 = performance.now();
       createOverlay();
@@ -2462,6 +2474,9 @@ if (!window.__SMRUTI_QUICK_SEARCH_LOADED__) {
       updateModeBadge(mode);
       cachedTabs = null;
       cachedBookmarks = null;
+      // Onboarding checklist milestones (fire on mode entry, not every keystroke).
+      if (mode === 'commands') { markMilestoneOnce('firstSlashCommand'); }
+      else if (mode === 'websearch') { markMilestoneOnce('firstWebSearch'); }
     }
 
     if (mode === 'help') {

--- a/src/content_scripts/quick-search.ts
+++ b/src/content_scripts/quick-search.ts
@@ -83,6 +83,7 @@ import {
   getTipState,
   recordTipShown,
 } from '../shared/onboarding/tips';
+import { buildCheatsheetSections } from '../shared/onboarding/cheatsheet';
 import {
   type PaletteMode,
   type PaletteRowAttrs,
@@ -2570,6 +2571,17 @@ if (!window.__SMRUTI_QUICK_SEARCH_LOADED__) {
     resultsEl.innerHTML = '';
     resultsEl.className = 'results list';
 
+    // Silo C: rich cheatsheet (every prefix + shortcut + web engine, one shared source)
+    // when enabled; otherwise the original minimal help below as a safe fallback.
+    const cheatsheetOn =
+      cachedSettings?.onboardingEnabled !== false &&
+      cachedSettings?.onboardingCheatsheetEnabled !== false;
+    if (cheatsheetOn) {
+      renderRichCheatsheet();
+      updateResultCount('');
+      return;
+    }
+
     const modes = [
       { prefix: '/',  label: 'Commands',      desc: 'Toggle settings, page actions, navigation' },
       { prefix: '>',  label: 'Power / Admin',  desc: 'Index, diagnostics, tuning presets, AI copy, data tools' },
@@ -2625,6 +2637,78 @@ if (!window.__SMRUTI_QUICK_SEARCH_LOADED__) {
     });
 
     updateResultCount('');
+  }
+
+  // Silo C: rich, data-driven cheatsheet built from the shared single source
+  // (buildCheatsheetSections). Palette-mode rows stay clickable to prefix the input.
+  function renderRichCheatsheet(): void {
+    if (!resultsEl) {return;}
+    const enabledModes = cachedSettings?.commandPaletteModes ?? ['/', '>', '@', '#', '??'];
+    const sections = buildCheatsheetSections({ enabledModes });
+
+    for (const section of sections) {
+      const divider = document.createElement('li');
+      divider.style.cssText = 'padding:6px 12px;font-size:10px;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-secondary);cursor:default;border-top:1px solid var(--border-color);margin-top:4px;';
+      divider.textContent = section.title;
+      resultsEl.appendChild(divider);
+
+      for (const entry of section.entries) {
+        const li = document.createElement('li');
+        li.className = 'command-row';
+        const disabled = entry.enabled === false;
+        if (disabled) {li.style.opacity = '0.4';}
+
+        const keys = document.createElement('span');
+        keys.className = 'cmd-icon';
+        keys.style.cssText = 'font-family:ui-monospace,SFMono-Regular,monospace;font-size:13px;font-weight:700;color:var(--accent-color);min-width:42px;text-align:center;';
+        keys.textContent = entry.keys;
+
+        const label = document.createElement('span');
+        label.className = 'cmd-label';
+        label.textContent = entry.label;
+        if (entry.advanced) {
+          const badge = document.createElement('span');
+          badge.className = 'cmd-current';
+          badge.textContent = ' [advanced]';
+          label.appendChild(badge);
+        }
+        if (disabled) {
+          const badge = document.createElement('span');
+          badge.className = 'cmd-current';
+          badge.textContent = ' [disabled]';
+          label.appendChild(badge);
+        }
+
+        li.append(keys, label);
+
+        // Palette-mode rows remain clickable (prefix the input); `?` help is meta-only.
+        if (section.id === 'palette' && !disabled && entry.keys !== '?') {
+          li.addEventListener('click', () => {
+            if (inputEl) {
+              inputEl.value = entry.keys;
+              inputEl.dispatchEvent(new Event('input'));
+              inputEl.focus();
+            }
+          });
+        }
+        resultsEl.appendChild(li);
+      }
+    }
+
+    // Guided-tour pointer (not part of the data-driven cheatsheet).
+    const tourLi = document.createElement('li');
+    tourLi.className = 'command-row';
+    const tourIcon = document.createElement('span');
+    tourIcon.className = 'cmd-icon';
+    tourIcon.textContent = '🎯';
+    const tourLabel = document.createElement('span');
+    tourLabel.className = 'cmd-label';
+    tourLabel.textContent = 'Guided Tour';
+    const tourCat = document.createElement('span');
+    tourCat.className = 'cmd-category';
+    tourCat.textContent = 'Type /tour to start the interactive tour';
+    tourLi.append(tourIcon, tourLabel, tourCat);
+    resultsEl.appendChild(tourLi);
   }
 
   // ===== COMMAND PALETTE: PALETTE MODE HANDLER =====

--- a/src/content_scripts/quick-search.ts
+++ b/src/content_scripts/quick-search.ts
@@ -2762,6 +2762,16 @@ if (!window.__SMRUTI_QUICK_SEARCH_LOADED__) {
 
     updateResultCount(`${displayList.length} command${displayList.length !== 1 ? 's' : ''}`);
 
+    // Power-tier safety warning — these commands change browser/extension state.
+    if (tier === 'power') {
+      const warn = document.createElement('li');
+      warn.className = 'palette-discovery-tip';
+      warn.setAttribute('role', 'presentation');
+      warn.style.color = 'var(--accent-color)';
+      warn.textContent = '⚠️ Power commands change browser/extension state — read each one before running.';
+      resultsEl.appendChild(warn);
+    }
+
     const emptyQuery = !query.trim();
     const showCategoryHeaders = emptyQuery;
     let lastCategory = '';

--- a/src/content_scripts/quick-search.ts
+++ b/src/content_scripts/quick-search.ts
@@ -76,6 +76,14 @@ import {
 import { wireHideImgOnError } from '../shared/hide-img-on-error';
 import { markMilestone, type MilestoneId } from '../shared/onboarding/milestones';
 import {
+  PALETTE_TIP_ID,
+  TIP_DEFINITIONS,
+  areTipsEnabled,
+  shouldShowTip,
+  getTipState,
+  recordTipShown,
+} from '../shared/onboarding/tips';
+import {
   type PaletteMode,
   type PaletteRowAttrs,
   type ResolvedCopyTarget,
@@ -2296,7 +2304,7 @@ if (!window.__SMRUTI_QUICK_SEARCH_LOADED__) {
         container.classList.add('unified-scroll');
       }
       loadRecentHistory();
-      showFirstUseHint();
+      void showFirstUseHint();
     }).catch(() => loadRecentHistory());
     
     // NUCLEAR OPTION: Force blur current element (omnibox) then focus aggressively
@@ -3579,18 +3587,31 @@ if (!window.__SMRUTI_QUICK_SEARCH_LOADED__) {
 
   // ===== COMMAND PALETTE: WEB SEARCH =====
 
-  function showFirstUseHint(): void {
+  // Silo B: replayable just-in-time tip. Replaces the old permanent
+  // commandPaletteOnboarded latch with a max-shows + cooldown policy, so the hint
+  // can resurface for users who never noticed it (gated by onboardingTipsEnabled).
+  async function showFirstUseHint(): Promise<void> {
     if (!resultsEl || !cachedSettings) {return;}
     if (!cachedSettings.commandPaletteEnabled) {return;}
-    if (cachedSettings.commandPaletteOnboarded) {return;}
-
+    if (!areTipsEnabled(cachedSettings)) {return;}
     if (firstUseHintEl) {return;}
+
+    const tip = TIP_DEFINITIONS[PALETTE_TIP_ID];
+    if (!tip) {return;}
+
+    const state = await getTipState();
+    if (!shouldShowTip(state[PALETTE_TIP_ID], Date.now())) {return;}
+
+    // Re-check guards after the await — settings/DOM may have changed meanwhile.
+    if (!resultsEl || firstUseHintEl) {return;}
 
     firstUseHintEl = document.createElement('div');
     firstUseHintEl.className = 'first-use-hint';
-    firstUseHintEl.textContent = 'New: Type / for commands, @ for tabs, # for bookmarks';
+    firstUseHintEl.textContent = tip.message;
 
     resultsEl.parentElement?.insertBefore(firstUseHintEl, resultsEl);
+
+    void recordTipShown(PALETTE_TIP_ID);
 
     firstUseHintTimer = window.setTimeout(() => {
       dismissFirstUseHint();

--- a/src/core/__tests__/fresh-install-profile.test.ts
+++ b/src/core/__tests__/fresh-install-profile.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { FRESH_INSTALL_PROFILE } from '../fresh-install-profile';
+import { SETTINGS_SCHEMA } from '../settings';
+
+describe('FRESH_INSTALL_PROFILE', () => {
+  describe('schema validity (guards against drift)', () => {
+    it('every profile key exists in SETTINGS_SCHEMA', () => {
+      for (const key of Object.keys(FRESH_INSTALL_PROFILE)) {
+        expect(SETTINGS_SCHEMA, `profile key "${key}" must exist in the schema`).toHaveProperty(key);
+      }
+    });
+
+    it('every profile value passes its schema validate()', () => {
+      const schema = SETTINGS_SCHEMA as Record<string, { validate?: (v: unknown) => boolean }>;
+      for (const [key, value] of Object.entries(FRESH_INSTALL_PROFILE)) {
+        const entry = schema[key];
+        if (entry?.validate) {
+          expect(entry.validate(value), `${key}=${JSON.stringify(value)} should pass schema validate()`).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe('safety policy — dangerous / heavy features stay opt-in', () => {
+    it('does NOT enable advancedBrowserCommands', () => {
+      expect(FRESH_INSTALL_PROFILE).not.toHaveProperty('advancedBrowserCommands');
+    });
+
+    it('does NOT enable Ollama or embeddings (they need a local install)', () => {
+      expect(FRESH_INSTALL_PROFILE).not.toHaveProperty('ollamaEnabled');
+      expect(FRESH_INSTALL_PROFILE).not.toHaveProperty('embeddingsEnabled');
+    });
+
+    it('does NOT force the command palette into the popup', () => {
+      expect(FRESH_INSTALL_PROFILE).not.toHaveProperty('commandPaletteInPopup');
+    });
+
+    it('excludes the > power prefix from commandPaletteModes', () => {
+      expect(FRESH_INSTALL_PROFILE.commandPaletteModes).toBeDefined();
+      expect(FRESH_INSTALL_PROFILE.commandPaletteModes).not.toContain('>');
+    });
+  });
+
+  describe('opinionated safe defaults are ON', () => {
+    it('enables the command palette with the safe prefixes', () => {
+      expect(FRESH_INSTALL_PROFILE.commandPaletteEnabled).toBe(true);
+      expect(FRESH_INSTALL_PROFILE.commandPaletteModes).toEqual(
+        expect.arrayContaining(['/', '@', '#', '??']),
+      );
+    });
+
+    it('indexes bookmarks and shows recent history/searches', () => {
+      expect(FRESH_INSTALL_PROFILE.indexBookmarks).toBe(true);
+      expect(FRESH_INSTALL_PROFILE.showRecentHistory).toBe(true);
+      expect(FRESH_INSTALL_PROFILE.showRecentSearches).toBe(true);
+    });
+
+    it('turns on the whole onboarding system', () => {
+      expect(FRESH_INSTALL_PROFILE.onboardingEnabled).toBe(true);
+      expect(FRESH_INSTALL_PROFILE.onboardingChecklistEnabled).toBe(true);
+      expect(FRESH_INSTALL_PROFILE.onboardingTipsEnabled).toBe(true);
+      expect(FRESH_INSTALL_PROFILE.onboardingCheatsheetEnabled).toBe(true);
+      expect(FRESH_INSTALL_PROFILE.onboardingDemosEnabled).toBe(true);
+    });
+  });
+});

--- a/src/core/__tests__/settings.test.ts
+++ b/src/core/__tests__/settings.test.ts
@@ -960,6 +960,11 @@ describe('SettingsManager', () => {
         'showDuplicateUrls',
         'showNonMatchingResults',
         'selectAllOnFocus',
+        'onboardingEnabled',
+        'onboardingChecklistEnabled',
+        'onboardingTipsEnabled',
+        'onboardingCheatsheetEnabled',
+        'onboardingDemosEnabled',
       ] as const;
 
       for (const key of booleanKeys) {
@@ -988,6 +993,11 @@ describe('SettingsManager', () => {
             showDuplicateUrls: false,
             showNonMatchingResults: false,
             selectAllOnFocus: false,
+            onboardingEnabled: true,
+            onboardingChecklistEnabled: true,
+            onboardingTipsEnabled: true,
+            onboardingCheatsheetEnabled: true,
+            onboardingDemosEnabled: true,
           };
           expect(SettingsManager.getSetting(key)).toBe(defaults[key]);
         });
@@ -1021,6 +1031,32 @@ describe('SettingsManager', () => {
           expect(SettingsManager.getSetting(key)).toBe(defaults[key]);
         });
       }
+    });
+
+    describe('welcomeShownVersion', () => {
+      it('should default to empty string', async () => {
+        const { SettingsManager } = await getManagerWithStoredSettings({});
+        await SettingsManager.init();
+        expect(SettingsManager.getSetting('welcomeShownVersion')).toBe('');
+      });
+
+      it('should accept a version string', async () => {
+        const { SettingsManager } = await getManagerWithStoredSettings({ welcomeShownVersion: '9.5.0' });
+        await SettingsManager.init();
+        expect(SettingsManager.getSetting('welcomeShownVersion')).toBe('9.5.0');
+      });
+
+      it('should accept empty string (unlike length-required string keys)', async () => {
+        const { SettingsManager } = await getManagerWithStoredSettings({ welcomeShownVersion: '' });
+        await SettingsManager.init();
+        expect(SettingsManager.getSetting('welcomeShownVersion')).toBe('');
+      });
+
+      it('should reject non-string and fall back to default', async () => {
+        const { SettingsManager } = await getManagerWithStoredSettings({ welcomeShownVersion: 123 });
+        await SettingsManager.init();
+        expect(SettingsManager.getSetting('welcomeShownVersion')).toBe('');
+      });
     });
   });
 

--- a/src/core/__tests__/settings.test.ts
+++ b/src/core/__tests__/settings.test.ts
@@ -590,6 +590,33 @@ describe('SettingsManager', () => {
   });
 
   // -----------------------------------------------------------------------
+  // reloadFromStorage()
+  // -----------------------------------------------------------------------
+  describe('reloadFromStorage', () => {
+    it('merges the latest persisted settings into the in-memory cache', async () => {
+      const { SettingsManager } = await getManagerWithStoredSettings({
+        commandPaletteInPopup: true,
+        logLevel: 4,
+      });
+
+      // Before reload, in-memory is schema defaults.
+      expect(SettingsManager.getSetting('commandPaletteInPopup')).toBe(false);
+
+      await SettingsManager.reloadFromStorage();
+
+      // After reload, the persisted values are reflected (the fix that prevents the
+      // fresh-install profile from clobbering a concurrently-written setting).
+      expect(SettingsManager.getSetting('commandPaletteInPopup')).toBe(true);
+      expect(SettingsManager.getSetting('logLevel')).toBe(4);
+    });
+
+    it('is a no-op when storage has no settings', async () => {
+      const { SettingsManager } = await getManagerWithNoStorage();
+      await expect(SettingsManager.reloadFromStorage()).resolves.toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // resetToDefaults()
   // -----------------------------------------------------------------------
   describe('resetToDefaults', () => {

--- a/src/core/fresh-install-profile.ts
+++ b/src/core/fresh-install-profile.ts
@@ -1,0 +1,59 @@
+// fresh-install-profile.ts — the "fully set-up gift" applied ONCE on a brand-new install.
+//
+// ┌──────────────────────────────────────────────────────────────────────────┐
+// │  THIS IS THE ONE PLACE TO TUNE THE OUT-OF-BOX EXPERIENCE.                   │
+// │  Edit a single line here to change what every brand-new user starts with.  │
+// └──────────────────────────────────────────────────────────────────────────┘
+//
+// HOW IT RELATES TO settings.ts (the single source of truth):
+//   • SETTINGS_SCHEMA (settings.ts) owns the SHAPE + the SAFE BASELINE default of
+//     every setting. That baseline is deliberately conservative.
+//   • FRESH_INSTALL_PROFILE (this file) is an opinionated, documented OVERLAY of a
+//     SUBSET of those same keys — "what a brand-new user should start with", which
+//     can be more generous than the conservative baseline.
+//   • It is typed `Partial<AppSettings>`, so EVERY key here must be a real settings
+//     key with a correctly-typed value — the compiler rejects typos and drift.
+//     We never invent keys or values the schema wouldn't validate.
+//
+// WHEN IT APPLIES:
+//   • Exactly once, on chrome.runtime.onInstalled with reason === 'install'.
+//   • Existing users upgrading (reason === 'update') are NEVER touched — their
+//     chosen settings are preserved. See lifecycle/fresh-install.ts.
+//
+// THE POLICY (Spring-Boot-style "max SAFE auto-config"):
+//   • Turn ON safe, high-value features so the extension feels fully set up.
+//   • Keep DANGEROUS / heavy / setup-requiring features OFF (opt-in), so a brand-new
+//     user is never handed a loaded gun and never hits a "why is this broken?" wall.
+
+import type { AppSettings } from './settings';
+
+export const FRESH_INSTALL_PROFILE: Partial<AppSettings> = {
+  // ── SAFE high-value features: ON out of the box ──────────────────────────────
+  commandPaletteEnabled: true,                // prefix modes available immediately
+  commandPaletteModes: ['/', '@', '#', '??'], // NOTE: '>' (power tier) is intentionally
+                                              // dropped for new users — it's opt-in and
+                                              // warned (progressive disclosure). They can
+                                              // enable it later via Settings / the palette.
+  indexBookmarks: true,                       // bookmarks searchable from day one
+  showRecentHistory: true,                    // empty popup shows recent pages…
+  showRecentSearches: true,                   // …and recent searches (useful, not noisy)
+
+  // ── Onboarding / teaching: ON for the new user ───────────────────────────────
+  // (These also default true in the schema; restated here so this file is the
+  //  complete, self-documenting picture of a fresh install. Flip any line to false
+  //  to ship a new install with that piece off.)
+  onboardingEnabled: true,                    // master switch for welcome + all silos
+  onboardingChecklistEnabled: true,           // Silo A: learn-by-doing checklist
+  onboardingTipsEnabled: true,                // Silo B: replayable just-in-time tips
+  onboardingCheatsheetEnabled: true,          // Silo C: rich `?` cheatsheet panel
+  onboardingDemosEnabled: true,               // Silo D: animated demos on welcome page
+
+  // ── DELIBERATELY OMITTED (kept at the conservative schema baseline = OFF) ─────
+  //   advancedBrowserCommands → ~45 power commands + a Chrome optional-permission
+  //                             prompt. Opt-in only.
+  //   ollamaEnabled / embeddingsEnabled → require a local Ollama install; turning
+  //                             them on by default would surface "AI offline" errors.
+  //   commandPaletteInPopup   → keep the popup simple by default; the overlay is the
+  //                             power surface.
+  //   '>' power prefix        → see commandPaletteModes above.
+};

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -75,6 +75,20 @@ export interface AppSettings {
      * SETTINGS_CHANGED tick.
      */
     reportButtonEnabled?: boolean;
+    // --- Onboarding / user education (each silo independently toggleable) ---
+    // Master kill-switch for the whole onboarding system: welcome page + all four
+    // teaching silos. Flip to false to disable everything at once. Default true.
+    onboardingEnabled?: boolean;
+    // Silo A — learn-by-doing checklist card in the popup. Default true.
+    onboardingChecklistEnabled?: boolean;
+    // Silo B — replayable "Did you know?" just-in-time tips (NOT a one-shot). Default true.
+    onboardingTipsEnabled?: boolean;
+    // Silo C — rich `?` cheatsheet / reference panel (prefixes, shortcuts, engines). Default true.
+    onboardingCheatsheetEnabled?: boolean;
+    // Silo D — animated demos embedded in the welcome page. Default true.
+    onboardingDemosEnabled?: boolean;
+    // Last extension version whose welcome page auto-opened — gates re-show on upgrade. Default ''.
+    welcomeShownVersion?: string;
     // Future settings can be added here
     theme?: 'light' | 'dark' | 'auto';
     maxResults?: number;
@@ -325,6 +339,35 @@ const SETTINGS_SCHEMA: { [K in keyof Required<AppSettings>]: SettingSchema<AppSe
     reportButtonEnabled: {
         default: true,
         validate: (val) => typeof val === 'boolean',
+    },
+
+    // --- Onboarding / user education ---
+    // Each silo gets its own flag so any one can be disabled independently if it
+    // misbehaves; onboardingEnabled is the master kill-switch over all of them.
+    // All default ON — teaching is harmless, revisitable, and individually toggleable.
+    onboardingEnabled: {
+        default: true,
+        validate: (val) => typeof val === 'boolean',
+    },
+    onboardingChecklistEnabled: {
+        default: true,
+        validate: (val) => typeof val === 'boolean',
+    },
+    onboardingTipsEnabled: {
+        default: true,
+        validate: (val) => typeof val === 'boolean',
+    },
+    onboardingCheatsheetEnabled: {
+        default: true,
+        validate: (val) => typeof val === 'boolean',
+    },
+    onboardingDemosEnabled: {
+        default: true,
+        validate: (val) => typeof val === 'boolean',
+    },
+    welcomeShownVersion: {
+        default: '',
+        validate: (val) => typeof val === 'string',
     },
 
     // Future settings (placeholders)

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -522,6 +522,24 @@ export class SettingsManager {
     }
 
     /**
+     * Re-read persisted settings from storage into the in-memory cache, merging
+     * over current values. Picks up writes made by another context after init()
+     * (e.g. an early SETTINGS_CHANGED, a synced device, or a test harness). Used
+     * before applying the fresh-install profile so profile application merges over
+     * the LATEST persisted state and never clobbers a concurrently-written setting.
+     */
+    static async reloadFromStorage(): Promise<void> {
+        try {
+            const stored = await this.loadFromStorage();
+            if (stored) {
+                this.settings = { ...this.settings, ...stored };
+            }
+        } catch (error) {
+            this.logger.warn('reloadFromStorage', 'Failed to reload settings from storage', errorMeta(error));
+        }
+    }
+
+    /**
      * Get specific setting value
      */
     static getSetting<K extends keyof AppSettings>(key: K): AppSettings[K] {

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -107,8 +107,12 @@ interface SettingSchema<T> {
 /**
  * SINGLE SOURCE OF TRUTH for all settings
  * Adding a new setting = ONE entry here. That's it!
+ *
+ * Exported read-only so tooling (e.g. fresh-install-profile validation tests) can
+ * verify keys/values against the schema. This is still the ONE schema — exporting
+ * it does not create a second source of truth.
  */
-const SETTINGS_SCHEMA: { [K in keyof Required<AppSettings>]: SettingSchema<AppSettings[K]> } = {
+export const SETTINGS_SCHEMA: { [K in keyof Required<AppSettings>]: SettingSchema<AppSettings[K]> } = {
     // Display settings
     displayMode: {
         default: DisplayMode.LIST,

--- a/src/popup/__tests__/confirm-undo.test.ts
+++ b/src/popup/__tests__/confirm-undo.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { confirmDestructive, showUndoToast } from '../confirm-undo';
+
+function dialogButtons(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll('.cu-dialog button')) as HTMLButtonElement[];
+}
+
+describe('confirmDestructive', () => {
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  it('renders the op title, consequences and a backup checkbox', async () => {
+    const p = confirmDestructive('clear', { offerBackup: true });
+    const dialog = document.querySelector('.cu-dialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.textContent).toContain('Clear index');
+    expect(document.querySelectorAll('.cu-dialog li').length).toBeGreaterThan(0);
+    expect(document.querySelector('.cu-dialog input[type="checkbox"]')).not.toBeNull();
+    dialogButtons()[1]!.click(); // confirm — settle the promise
+    await p;
+  });
+
+  it('resolves {confirmed:true, backup:true} when confirmed with backup checked', async () => {
+    const p = confirmDestructive('clear', { offerBackup: true });
+    dialogButtons()[1]!.click(); // confirm ([0] is cancel)
+    await expect(p).resolves.toEqual({ confirmed: true, backup: true });
+    expect(document.querySelector('.cu-overlay')).toBeNull(); // dialog removed
+  });
+
+  it('resolves {confirmed:false} when cancelled', async () => {
+    const p = confirmDestructive('factoryReset', { offerBackup: true });
+    dialogButtons()[0]!.click(); // cancel
+    await expect(p).resolves.toEqual({ confirmed: false, backup: false });
+  });
+
+  it('omits the backup checkbox when offerBackup is not set', async () => {
+    const p = confirmDestructive('clear', {});
+    expect(document.querySelector('.cu-dialog input[type="checkbox"]')).toBeNull();
+    dialogButtons()[1]!.click();
+    await p;
+  });
+});
+
+describe('showUndoToast', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); document.body.innerHTML = ''; });
+
+  it('shows a toast whose Undo button runs onUndo and dismisses', () => {
+    const onUndo = vi.fn();
+    showUndoToast('Cleared.', onUndo, 10_000);
+    const toast = document.querySelector('.cu-undo-toast');
+    expect(toast).not.toBeNull();
+    expect(toast?.textContent).toContain('Cleared.');
+    (toast!.querySelector('button') as HTMLButtonElement).click();
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.cu-undo-toast')).toBeNull();
+  });
+
+  it('auto-dismisses after the window elapses without calling onUndo', () => {
+    const onUndo = vi.fn();
+    showUndoToast('Cleared.', onUndo, 10_000);
+    expect(document.querySelector('.cu-undo-toast')).not.toBeNull();
+    vi.advanceTimersByTime(10_000);
+    expect(document.querySelector('.cu-undo-toast')).toBeNull();
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+});

--- a/src/popup/__tests__/safety-utils.test.ts
+++ b/src/popup/__tests__/safety-utils.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  UNDO_WINDOW_MS,
+  DESTRUCTIVE_OPS,
+  describeOp,
+  isSnapshotRestorable,
+  runWithUndo,
+} from '../safety-utils';
+
+describe('safety-utils — op registry', () => {
+  it('UNDO_WINDOW_MS is a sane window', () => {
+    expect(UNDO_WINDOW_MS).toBeGreaterThanOrEqual(5000);
+  });
+
+  it('clear and factoryReset are defined, undoable, and have consequences', () => {
+    for (const id of ['clear', 'factoryReset'] as const) {
+      const op = describeOp(id);
+      expect(op.id).toBe(id);
+      expect(op.undoable).toBe(true);
+      expect(op.consequences.length).toBeGreaterThan(0);
+      expect(op.confirmLabel.length).toBeGreaterThan(0);
+    }
+    expect(Object.keys(DESTRUCTIVE_OPS)).toEqual(['clear', 'factoryReset']);
+  });
+
+  it('isSnapshotRestorable accepts arrays only', () => {
+    expect(isSnapshotRestorable([])).toBe(true);
+    expect(isSnapshotRestorable([1, 2])).toBe(true);
+    expect(isSnapshotRestorable(null)).toBe(false);
+    expect(isSnapshotRestorable({})).toBe(false);
+    expect(isSnapshotRestorable(undefined)).toBe(false);
+  });
+});
+
+describe('safety-utils — runWithUndo', () => {
+  it('snapshots before running, then offers undo on success', async () => {
+    const order: string[] = [];
+    const snap = ['a'];
+    const restore = vi.fn().mockResolvedValue(undefined);
+    let undoFn: (() => void) | null = null;
+
+    const ok = await runWithUndo<string[]>({
+      snapshot: async () => { order.push('snapshot'); return snap; },
+      run: async () => { order.push('run'); return true; },
+      restore,
+      offerUndo: (undo) => { order.push('offer'); undoFn = undo; },
+    });
+
+    expect(ok).toBe(true);
+    expect(order).toEqual(['snapshot', 'run', 'offer']);
+    expect(restore).not.toHaveBeenCalled();
+    undoFn?.();
+    expect(restore).toHaveBeenCalledWith(snap);
+  });
+
+  it('does not offer undo when the op fails', async () => {
+    const offerUndo = vi.fn();
+    const ok = await runWithUndo<string[]>({
+      snapshot: async () => ['x'],
+      run: async () => false,
+      restore: vi.fn(),
+      offerUndo,
+    });
+    expect(ok).toBe(false);
+    expect(offerUndo).not.toHaveBeenCalled();
+  });
+
+  it('does not offer undo when no snapshot could be captured', async () => {
+    const offerUndo = vi.fn();
+    const ok = await runWithUndo<string[]>({
+      snapshot: async () => null,
+      run: async () => true,
+      restore: vi.fn(),
+      offerUndo,
+    });
+    expect(ok).toBe(true);
+    expect(offerUndo).not.toHaveBeenCalled();
+  });
+
+  it('treats a thrown snapshot as no-snapshot (op still runs, no undo offered)', async () => {
+    const offerUndo = vi.fn();
+    const run = vi.fn(async () => true);
+    const ok = await runWithUndo<string[]>({
+      snapshot: async () => { throw new Error('export failed'); },
+      run,
+      restore: vi.fn(),
+      offerUndo,
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(ok).toBe(true);
+    expect(offerUndo).not.toHaveBeenCalled();
+  });
+});

--- a/src/popup/confirm-undo.ts
+++ b/src/popup/confirm-undo.ts
@@ -1,0 +1,127 @@
+// confirm-undo.ts — styled confirmation dialog + undo toast for destructive ops.
+//
+// Self-contained DOM (appended to document.body, removed on close) so it never
+// collides with the existing settings-modal markup. Pure orchestration + the op
+// registry live in safety-utils.ts.
+
+import { DESTRUCTIVE_OPS, UNDO_WINDOW_MS, type DestructiveOpId } from './safety-utils';
+
+export interface ConfirmChoice {
+  confirmed: boolean;
+  /** True when the user kept "Export a backup first" ticked. */
+  backup: boolean;
+}
+
+/**
+ * Show a styled, consequence-clear confirmation dialog. Resolves with the user's
+ * choice. Replaces the easy-to-blow-through native confirm() for destructive ops.
+ */
+export function confirmDestructive(
+  id: DestructiveOpId,
+  opts: { offerBackup?: boolean } = {},
+): Promise<ConfirmChoice> {
+  const op = DESTRUCTIVE_OPS[id];
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'cu-overlay';
+    overlay.style.cssText =
+      'position:fixed;inset:0;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;z-index:2147483646;';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'cu-dialog';
+    dialog.setAttribute('role', 'alertdialog');
+    dialog.setAttribute('aria-modal', 'true');
+    dialog.style.cssText =
+      'background:var(--card,#161b22);color:var(--text,#e6edf3);border:1px solid var(--border,#2a313c);border-radius:12px;max-width:360px;width:calc(100% - 32px);padding:18px 20px;box-shadow:0 10px 40px rgba(0,0,0,0.5);font-family:inherit;';
+
+    const title = document.createElement('h2');
+    title.style.cssText = 'margin:0 0 10px;font-size:16px;';
+    title.textContent = op.title;
+    dialog.appendChild(title);
+
+    const list = document.createElement('ul');
+    list.style.cssText = 'margin:0 0 14px;padding-left:18px;font-size:13px;color:var(--muted,#8b949e);';
+    for (const c of op.consequences) {
+      const li = document.createElement('li');
+      li.textContent = c;
+      list.appendChild(li);
+    }
+    dialog.appendChild(list);
+
+    let backupCheckbox: HTMLInputElement | null = null;
+    if (opts.offerBackup) {
+      const label = document.createElement('label');
+      label.style.cssText = 'display:flex;align-items:center;gap:8px;font-size:13px;margin-bottom:14px;cursor:pointer;';
+      backupCheckbox = document.createElement('input');
+      backupCheckbox.type = 'checkbox';
+      backupCheckbox.checked = true; // default ON — safer
+      const span = document.createElement('span');
+      span.textContent = 'Export a backup first';
+      label.append(backupCheckbox, span);
+      dialog.appendChild(label);
+    }
+
+    const buttons = document.createElement('div');
+    buttons.style.cssText = 'display:flex;gap:10px;justify-content:flex-end;';
+    const cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.textContent = 'Cancel';
+    cancel.style.cssText =
+      'font:inherit;padding:8px 14px;border-radius:8px;border:1px solid var(--border,#2a313c);background:transparent;color:inherit;cursor:pointer;';
+    const confirm = document.createElement('button');
+    confirm.type = 'button';
+    confirm.textContent = op.confirmLabel;
+    confirm.style.cssText =
+      'font:inherit;padding:8px 14px;border-radius:8px;border:1px solid #f85149;background:#f85149;color:#fff;cursor:pointer;';
+    buttons.append(cancel, confirm);
+    dialog.appendChild(buttons);
+
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+    confirm.focus();
+
+    const close = (choice: ConfirmChoice): void => {
+      overlay.remove();
+      resolve(choice);
+    };
+    cancel.addEventListener('click', () => close({ confirmed: false, backup: false }));
+    confirm.addEventListener('click', () => close({ confirmed: true, backup: !!backupCheckbox?.checked }));
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) { close({ confirmed: false, backup: false }); }
+    });
+    overlay.addEventListener('keydown', (e) => {
+      if ((e as KeyboardEvent).key === 'Escape') { close({ confirmed: false, backup: false }); }
+    });
+  });
+}
+
+/**
+ * Show a bottom toast offering "Undo" for `ms` milliseconds. Clicking Undo runs
+ * `onUndo` and dismisses; otherwise it auto-dismisses.
+ */
+export function showUndoToast(message: string, onUndo: () => void, ms: number = UNDO_WINDOW_MS): void {
+  const toast = document.createElement('div');
+  toast.className = 'cu-undo-toast';
+  toast.style.cssText =
+    'position:fixed;left:50%;bottom:20px;transform:translateX(-50%);background:#161b22;color:#e6edf3;border:1px solid #2a313c;border-radius:10px;padding:10px 14px;display:flex;align-items:center;gap:12px;z-index:2147483647;box-shadow:0 8px 30px rgba(0,0,0,0.45);font-size:13px;';
+
+  const text = document.createElement('span');
+  text.textContent = message;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = 'Undo';
+  btn.style.cssText = 'font:inherit;font-weight:600;color:#58a6ff;background:transparent;border:none;cursor:pointer;';
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const dismiss = (): void => {
+    if (timer) { clearTimeout(timer); timer = null; }
+    toast.remove();
+  };
+  btn.addEventListener('click', () => {
+    dismiss();
+    onUndo();
+  });
+  toast.append(text, btn);
+  document.body.appendChild(toast);
+  timer = setTimeout(dismiss, ms);
+}

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1433,3 +1433,58 @@ input[type="checkbox"] {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ── Onboarding checklist (Silo A) ──────────────────────────────────────── */
+.onboarding-checklist {
+  background: var(--card);
+  border: 1px solid var(--accent);
+  border-radius: 10px;
+  padding: 8px 10px;
+  margin: 6px 0 4px;
+}
+.onboarding-checklist__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.onboarding-checklist__title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent);
+}
+.onboarding-checklist__close {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  padding: 2px 4px;
+}
+.onboarding-checklist__close:hover { color: var(--text); }
+.onboarding-checklist__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.onboarding-checklist__item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+}
+.onboarding-checklist__mark {
+  color: var(--muted);
+  flex-shrink: 0;
+  width: 12px;
+  text-align: center;
+}
+.onboarding-checklist__item.is-done .onboarding-checklist__mark { color: var(--accent); }
+.onboarding-checklist__item.is-done .onboarding-checklist__label {
+  color: var(--muted);
+  text-decoration: line-through;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -69,6 +69,7 @@
       </div>
       <div id="toggle-bar" class="toggle-bar"></div>
       <div class="controls">
+        <button id="welcome-button" class="settings-button" title="Onboarding guide">👋</button>
         <button id="tour-button" class="settings-button tour-help-btn" title="Feature Tour & Help">?</button>
         <button id="settings-button" class="settings-button" title="Open Settings">
           <img src="../assets/icon-settings.svg" alt="Settings" class="settings-icon" />

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -496,6 +496,7 @@
           <div class="setting-actions">
             <button class="action-btn primary" id="modal-rebuild" title="Re-index all browser history">🔄 Rebuild Index</button>
             <button class="action-btn secondary" id="modal-reset" title="Reset settings to defaults — keeps your browsing index intact">↺ Reset Settings</button>
+            <button class="action-btn secondary" id="modal-reset-safe" title="Restore the recommended fresh-install setup (palette + bookmarks + onboarding on) — keeps your browsing index intact">🛟 Reset to Safe Defaults</button>
             <button class="action-btn danger" id="modal-clear" title="Clear browsing index and rebuild — settings unchanged">🗑️ Clear & Rebuild</button>
             <button class="action-btn danger" id="modal-factory-reset" title="Complete factory reset: clears index, resets settings, clears all caches, then rebuilds">⚠️ Factory Reset</button>
           </div>
@@ -538,7 +539,7 @@
               <input type="checkbox" id="modal-palette-mode-angle" value=">" disabled>
               <div class="toggle-content">
                 <strong>> Power</strong>
-                <small>Admin: rebuild index, clear data, diagnostics, factory reset</small>
+                <small>Admin: rebuild index, clear data, diagnostics, factory reset. ⚠️ These change browser/extension state — read each command before running it.</small>
               </div>
               <span class="toggle-switch"><span class="toggle-thumb"></span></span>
             </label>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -90,6 +90,7 @@
           <option value="alphabetical">Alphabetical</option>
         </select>
       </div>
+      <div id="onboarding-checklist"></div>
       <div class="result-count-row">
         <div class="search-spinner" id="search-spinner"></div>
         <div id="result-count" class="result-count" aria-live="polite"></div>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -15,6 +15,7 @@ import { addRecentInteraction, getRecentInteractions, clearRecentInteractions } 
 import { POPUP_TOUR_STEPS, runTour, isTourCompleted } from '../shared/tour';
 import { initChecklist } from '../shared/onboarding/checklist';
 import { markMilestone, type MilestoneId } from '../shared/onboarding/milestones';
+import { buildCheatsheetSections } from '../shared/onboarding/cheatsheet';
 import { TOOLBAR_TOGGLE_DEFS, DEFAULT_TOOLBAR_TOGGLES } from '../shared/toolbar-toggles';
 import { renderToolbarToggles, syncToolbarToggles, setChipBusy, injectToolbarToggleCss, type SettingsPort } from '../shared/toolbar-renderer';
 import {
@@ -885,6 +886,16 @@ function initializePopup() {
     resultsList.innerHTML = '';
     resultsList.className = 'results list';
 
+    // Silo C: rich cheatsheet (shared source) when enabled; minimal help as fallback.
+    const cheatsheetOn =
+      SettingsManager.getSetting('onboardingEnabled') !== false &&
+      SettingsManager.getSetting('onboardingCheatsheetEnabled') !== false;
+    if (cheatsheetOn) {
+      renderPopupRichCheatsheet(resultsList);
+      resultCountNode.textContent = '';
+      return;
+    }
+
     const cpModes = SettingsManager.getSetting('commandPaletteModes') ?? ['/', '>', '@', '#', '??'];
 
     const modes = [
@@ -940,6 +951,57 @@ function initializePopup() {
     });
 
     resultCountNode.textContent = '';
+  }
+
+  // Silo C: data-driven cheatsheet for the popup `?` help (shares buildCheatsheetSections
+  // with the overlay and welcome page). Palette-mode rows stay clickable to prefix input.
+  function renderPopupRichCheatsheet(resultsList: HTMLUListElement): void {
+    const enabledModes = SettingsManager.getSetting('commandPaletteModes') ?? ['/', '>', '@', '#', '??'];
+    const muted = 'font-size:10px;color:var(--muted);';
+    for (const section of buildCheatsheetSections({ enabledModes })) {
+      const divider = document.createElement('li');
+      divider.style.cssText = 'padding:6px 12px;font-size:10px;text-transform:uppercase;letter-spacing:0.5px;color:var(--muted);cursor:default;border-top:1px solid var(--border,#e5e7eb);margin-top:4px;';
+      divider.textContent = section.title;
+      resultsList.appendChild(divider);
+
+      for (const entry of section.entries) {
+        const disabled = entry.enabled === false;
+        const clickable = section.id === 'palette' && !disabled && entry.keys !== '?';
+        const li = document.createElement('li');
+        li.style.cssText = `display:flex;align-items:center;gap:8px;padding:8px 12px;border-radius:6px;border:1px solid transparent;background:var(--card);${disabled ? 'opacity:0.4;' : ''}${clickable ? 'cursor:pointer;' : 'cursor:default;'}`;
+
+        const keys = document.createElement('span');
+        keys.style.cssText = 'font-family:ui-monospace,SFMono-Regular,monospace;font-size:13px;font-weight:700;color:var(--accent,#3b82f6);min-width:42px;text-align:center;';
+        keys.textContent = entry.keys;
+
+        const label = document.createElement('span');
+        label.style.cssText = 'flex:1;font-size:13px;font-weight:500;';
+        label.textContent = entry.label;
+        if (entry.advanced) {
+          const b = document.createElement('span'); b.style.cssText = muted; b.textContent = ' [advanced]'; label.appendChild(b);
+        }
+        if (disabled) {
+          const b = document.createElement('span'); b.style.cssText = muted; b.textContent = ' [disabled]'; label.appendChild(b);
+        }
+        li.append(keys, label);
+
+        if (clickable) {
+          li.addEventListener('click', () => {
+            const input = $('search-input') as HTMLInputElement;
+            if (input) { input.value = entry.keys; input.dispatchEvent(new Event('input')); input.focus(); }
+          });
+        }
+        resultsList.appendChild(li);
+      }
+    }
+
+    const tourLi = document.createElement('li');
+    tourLi.style.cssText = 'display:flex;align-items:center;gap:8px;padding:8px 12px;border-radius:6px;border:1px solid transparent;background:var(--card);cursor:default;';
+    const ti = document.createElement('span'); ti.style.cssText = 'font-size:16px;width:24px;text-align:center;'; ti.textContent = '🎯';
+    const tl = document.createElement('span'); tl.style.cssText = 'flex:1;font-size:13px;font-weight:500;'; tl.textContent = 'Guided Tour';
+    const tc = document.createElement('span'); tc.style.cssText = muted; tc.textContent = 'Type /tour to start the interactive tour';
+    tourLi.append(ti, tl, tc);
+    resultsList.appendChild(tourLi);
   }
 
   function renderPopupPaletteResults(mode: PopupPaletteMode, query: string): void {

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -16,6 +16,8 @@ import { POPUP_TOUR_STEPS, runTour, isTourCompleted } from '../shared/tour';
 import { initChecklist } from '../shared/onboarding/checklist';
 import { markMilestone, type MilestoneId } from '../shared/onboarding/milestones';
 import { buildCheatsheetSections } from '../shared/onboarding/cheatsheet';
+import { runWithUndo } from './safety-utils';
+import { confirmDestructive, showUndoToast } from './confirm-undo';
 import { TOOLBAR_TOGGLE_DEFS, DEFAULT_TOOLBAR_TOGGLES } from '../shared/toolbar-toggles';
 import { renderToolbarToggles, syncToolbarToggles, setChipBusy, injectToolbarToggleCss, type SettingsPort } from '../shared/toolbar-renderer';
 import {
@@ -4344,32 +4346,81 @@ function initializePopup() {
       });
     }
 
+    // ── Destructive-op safety helpers (shared by Clear & Factory Reset) ──
+    // Snapshot the index via EXPORT_INDEX so a destructive op can be undone (or a
+    // backup downloaded). Restore re-imports via IMPORT_INDEX.
+    type IndexSnapshot = { version?: string; exportDate?: string; itemCount?: number; items: unknown[] };
+
+    async function captureIndexSnapshot(): Promise<IndexSnapshot | null> {
+      try {
+        const resp = await sendMessage({ type: 'EXPORT_INDEX' });
+        if (resp?.status === 'OK' && resp.data && Array.isArray(resp.data.items)) {
+          return resp.data as IndexSnapshot;
+        }
+      } catch (e) {
+        logger.debug('snapshot', 'EXPORT_INDEX failed; undo/backup unavailable', errorMeta(e));
+      }
+      return null;
+    }
+
+    function downloadIndexBackup(snap: IndexSnapshot): void {
+      try {
+        const blob = new Blob([JSON.stringify(snap, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `smruti-cortex-backup-${new Date().toISOString().slice(0, 10)}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch (e) {
+        logger.warn('backup', 'Backup download failed', errorMeta(e));
+      }
+    }
+
+    async function restoreIndexSnapshot(snap: IndexSnapshot): Promise<void> {
+      try {
+        await sendMessage({ type: 'IMPORT_INDEX', items: snap.items });
+        await fetchStorageQuotaInfo();
+        showToast('↩️ Restored your previous index.', 'info');
+      } catch (e) {
+        showToast('❌ Could not restore the backup', 'error');
+        logger.error('restore', 'IMPORT_INDEX failed', errorMeta(e));
+      }
+    }
+
     // Clear data button
     const clearBtn = modal.querySelector('#modal-clear') as HTMLButtonElement;
     if (clearBtn) {
       clearBtn.addEventListener('click', async () => {
-        if (!confirm('Clear index and rebuild?\n\nThis will:\n• Delete your browsing history index\n• Immediately rebuild from browser history\n\nSettings will NOT be changed. This takes a few seconds.')) {
-          return;
-        }
-        
+        const choice = await confirmDestructive('clear', { offerBackup: true });
+        if (!choice.confirmed) { return; }
+
         clearBtn.disabled = true;
         clearBtn.textContent = '⏳ Clearing & Rebuilding...';
+        const snap = await captureIndexSnapshot();           // capture once: backup + undo
+        if (choice.backup && snap) { downloadIndexBackup(snap); }
         showToast('🔄 Clearing data and rebuilding index...', 'info');
-        
+
         try {
-          const resp = await sendMessage({ type: 'CLEAR_ALL_DATA' });
-          if (resp && resp.status === 'OK') {
-            const itemCount = resp.itemCount || 0;
-            showToast(`✅ Done! ${itemCount} items re-indexed.`);
-            // Refresh storage quota display
-            await fetchStorageQuotaInfo();
-            // Clear local results
-            resultsLocal = [];
-            activeIndex = -1;
-            renderResults();
-          } else {
-            showToast('❌ Operation failed: ' + (resp?.message || 'Unknown error'), 'error');
-          }
+          await runWithUndo<IndexSnapshot>({
+            snapshot: async () => snap,
+            run: async () => {
+              const resp = await sendMessage({ type: 'CLEAR_ALL_DATA' });
+              if (resp && resp.status === 'OK') {
+                const itemCount = resp.itemCount || 0;
+                showToast(`✅ Done! ${itemCount} items re-indexed.`);
+                await fetchStorageQuotaInfo();
+                resultsLocal = [];
+                activeIndex = -1;
+                renderResults();
+                return true;
+              }
+              showToast('❌ Operation failed: ' + (resp?.message || 'Unknown error'), 'error');
+              return false;
+            },
+            restore: restoreIndexSnapshot,
+            offerUndo: (undo) => showUndoToast('Index cleared.', undo),
+          });
         } catch (error) {
           showToast('❌ Failed to clear data', 'error');
           logger.error('settingsModal', 'Clear all data failed', errorMeta(error));
@@ -4384,36 +4435,45 @@ function initializePopup() {
     const factoryResetBtn = modal.querySelector('#modal-factory-reset') as HTMLButtonElement;
     if (factoryResetBtn) {
       factoryResetBtn.addEventListener('click', async () => {
-        if (!confirm('Factory reset the extension?\n\nThis will:\n• Reset ALL settings to defaults\n• Clear ALL indexed data and caches\n• Rebuild the index from your browser history\n\nThis is a complete fresh start. It takes a few seconds.')) {
-          return;
-        }
+        const choice = await confirmDestructive('factoryReset', { offerBackup: true });
+        if (!choice.confirmed) { return; }
 
         factoryResetBtn.disabled = true;
         factoryResetBtn.textContent = '⏳ Resetting...';
+        const snap = await captureIndexSnapshot();           // capture once: backup + undo
+        if (choice.backup && snap) { downloadIndexBackup(snap); }
         showToast('⚙️ Factory resetting...', 'info');
 
         try {
-          // Reset settings first
-          await SettingsManager.resetToDefaults();
-          await Logger.setLevel(SettingsManager.getSetting('logLevel') ?? 2);
-          // Clear caches in parallel
-          await Promise.allSettled([
-            sendMessage({ type: 'CLEAR_FAVICON_CACHE' }),
-            sendMessage({ type: 'CLEAR_SEARCH_DEBUG' }),
-          ]);
-          // Clear all data and rebuild
-          const resp = await sendMessage({ type: 'CLEAR_ALL_DATA' });
-          if (resp && resp.status === 'OK') {
-            const itemCount = resp.itemCount || 0;
-            showToast(`✅ Factory reset complete! ${itemCount} items indexed.`);
-            await fetchStorageQuotaInfo();
-            resultsLocal = [];
-            activeIndex = -1;
-            renderResults();
-            closeSettingsModal();
-          } else {
-            showToast('❌ Factory reset failed: ' + (resp?.message || 'Unknown error'), 'error');
-          }
+          await runWithUndo<IndexSnapshot>({
+            snapshot: async () => snap,
+            run: async () => {
+              // Reset settings first
+              await SettingsManager.resetToDefaults();
+              await Logger.setLevel(SettingsManager.getSetting('logLevel') ?? 2);
+              // Clear caches in parallel
+              await Promise.allSettled([
+                sendMessage({ type: 'CLEAR_FAVICON_CACHE' }),
+                sendMessage({ type: 'CLEAR_SEARCH_DEBUG' }),
+              ]);
+              // Clear all data and rebuild
+              const resp = await sendMessage({ type: 'CLEAR_ALL_DATA' });
+              if (resp && resp.status === 'OK') {
+                const itemCount = resp.itemCount || 0;
+                showToast(`✅ Factory reset complete! ${itemCount} items indexed.`);
+                await fetchStorageQuotaInfo();
+                resultsLocal = [];
+                activeIndex = -1;
+                renderResults();
+                closeSettingsModal();
+                return true;
+              }
+              showToast('❌ Factory reset failed: ' + (resp?.message || 'Unknown error'), 'error');
+              return false;
+            },
+            restore: restoreIndexSnapshot,
+            offerUndo: (undo) => showUndoToast('Index cleared by factory reset.', undo),
+          });
         } catch (error) {
           showToast('❌ Factory reset failed', 'error');
           logger.error('settingsModal', 'Factory reset failed', errorMeta(error));

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -13,6 +13,8 @@ import { getRecentHistoryCache } from '../shared/recent-history-cache';
 import { addRecentSearch, getRecentSearches, clearRecentSearches } from '../shared/recent-searches';
 import { addRecentInteraction, getRecentInteractions, clearRecentInteractions } from '../shared/recent-interactions';
 import { POPUP_TOUR_STEPS, runTour, isTourCompleted } from '../shared/tour';
+import { initChecklist } from '../shared/onboarding/checklist';
+import { markMilestone, type MilestoneId } from '../shared/onboarding/milestones';
 import { TOOLBAR_TOGGLE_DEFS, DEFAULT_TOOLBAR_TOGGLES } from '../shared/toolbar-toggles';
 import { renderToolbarToggles, syncToolbarToggles, setChipBusy, injectToolbarToggleCss, type SettingsPort } from '../shared/toolbar-renderer';
 import {
@@ -75,6 +77,15 @@ import {
   highlightHtml,
   renderAIStatus as renderAIStatusShared,
 } from '../shared/search-ui-base';
+
+// Onboarding checklist (Silo A): mark a milestone at most once per popup session so
+// we never hit chrome.storage on every keystroke. markMilestone is itself idempotent.
+const _markedMilestones = new Set<MilestoneId>();
+function markMilestoneOnce(id: MilestoneId): void {
+  if (_markedMilestones.has(id)) { return; }
+  _markedMilestones.add(id);
+  void markMilestone(id);
+}
 
 // Lazy-loaded imports for non-critical features
 let tokenize: ((query: string) => string[]) | null = null;
@@ -303,7 +314,11 @@ function setupEventListeners() {
   // Removed - individual result items should be focusable instead
 
   if (input) {
-    input.addEventListener('input', (ev) => debounceSearch((ev.target as HTMLInputElement).value));
+    input.addEventListener('input', (ev) => {
+      const val = (ev.target as HTMLInputElement).value;
+      if (val.trim().length > 0) { markMilestoneOnce('firstSearch'); }
+      debounceSearch(val);
+    });
     input.addEventListener('keydown', handleKeydown);
   }
 
@@ -361,6 +376,9 @@ function setupEventListeners() {
       setTimeout(() => runTour(POPUP_TOUR_STEPS, document), 150);
     }
   });
+
+  // Onboarding checklist (Silo A) — renders only if enabled, not dismissed, not done.
+  void initChecklist(document.getElementById('onboarding-checklist'));
 
   // Settings modal tour link
   const settingsTourLink = document.getElementById('settings-tour-link');
@@ -2175,6 +2193,8 @@ function initializePopup() {
   function openResult(index: number, event?: MouseEvent | KeyboardEvent) {
     const item = resultsLocal[index];
     if (!item) {return;}
+
+    markMilestoneOnce('firstResultOpen');
 
     // Record recent search (fire-and-forget)
     if (currentQuery?.trim()) {

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -18,6 +18,7 @@ import { markMilestone, type MilestoneId } from '../shared/onboarding/milestones
 import { buildCheatsheetSections } from '../shared/onboarding/cheatsheet';
 import { runWithUndo } from './safety-utils';
 import { confirmDestructive, showUndoToast } from './confirm-undo';
+import { FRESH_INSTALL_PROFILE } from '../core/fresh-install-profile';
 import { TOOLBAR_TOGGLE_DEFS, DEFAULT_TOOLBAR_TOGGLES } from '../shared/toolbar-toggles';
 import { renderToolbarToggles, syncToolbarToggles, setChipBusy, injectToolbarToggleCss, type SettingsPort } from '../shared/toolbar-renderer';
 import {
@@ -4137,6 +4138,29 @@ function initializePopup() {
           closeSettingsModal();
           renderResults();
           showToast('Settings reset to defaults', 'info');
+        }
+      });
+    }
+
+    // Reset to Safe Defaults — the recommended fresh-install setup (keeps the index).
+    // Applies the schema baseline first, then the opinionated FRESH_INSTALL_PROFILE,
+    // so the result matches exactly what a brand-new install would start with.
+    const resetSafeBtn = modal.querySelector('#modal-reset-safe') as HTMLButtonElement;
+    if (resetSafeBtn) {
+      resetSafeBtn.addEventListener('click', async () => {
+        if (!confirm('Reset to safe defaults?\n\nThis restores the recommended setup (command palette, bookmark indexing and onboarding on; advanced/AI features stay off).\n\nYour browsing history index will NOT be affected.')) {
+          return;
+        }
+        try {
+          await SettingsManager.resetToDefaults();
+          await SettingsManager.updateSettings(FRESH_INSTALL_PROFILE);
+          await Logger.setLevel(SettingsManager.getSetting('logLevel') ?? 2);
+          closeSettingsModal();
+          renderResults();
+          showToast('✅ Restored safe defaults', 'info');
+        } catch (e) {
+          showToast('❌ Could not reset to safe defaults', 'error');
+          logger.error('settingsModal', 'Reset to safe defaults failed', errorMeta(e));
         }
       });
     }

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -345,6 +345,23 @@ function setupEventListeners() {
     });
   }
 
+  // Welcome / onboarding button — opens the replayable welcome page
+  const welcomeButton = $('welcome-button') as HTMLButtonElement | null;
+  if (welcomeButton) {
+    welcomeButton.addEventListener('click', () => {
+      chrome.runtime.sendMessage({ type: 'OPEN_WELCOME' });
+    });
+  }
+
+  // Replay the spotlight tour if the welcome page asked for it (flag set there).
+  // One-shot: clear the flag immediately so it only fires for this open.
+  chrome.storage.local.get('replayTourOnNextOpen', (res) => {
+    if (res?.replayTourOnNextOpen) {
+      chrome.storage.local.remove('replayTourOnNextOpen');
+      setTimeout(() => runTour(POPUP_TOUR_STEPS, document), 150);
+    }
+  });
+
   // Settings modal tour link
   const settingsTourLink = document.getElementById('settings-tour-link');
   if (settingsTourLink) {

--- a/src/popup/safety-utils.ts
+++ b/src/popup/safety-utils.ts
@@ -1,0 +1,92 @@
+// safety-utils.ts — pure helpers for the destructive-op guardrails (confirm + undo).
+//
+// No DOM, no chrome — just the op registry, copy, and the undo orchestration. The
+// DOM (styled dialog + undo toast) lives in confirm-undo.ts; the wiring lives in
+// popup.ts. Keeping this pure makes the safety logic fully unit-testable.
+
+/** How long the "Undo" affordance stays available after a destructive op. */
+export const UNDO_WINDOW_MS = 10_000;
+
+export type DestructiveOpId = 'clear' | 'factoryReset';
+
+export interface DestructiveOp {
+  id: DestructiveOpId;
+  title: string;
+  /** Plain-language bullet list of what will happen. */
+  consequences: string[];
+  /** Label for the confirm button. */
+  confirmLabel: string;
+  /** Whether an index snapshot → undo is meaningful for this op. */
+  undoable: boolean;
+}
+
+export const DESTRUCTIVE_OPS: Record<DestructiveOpId, DestructiveOp> = {
+  clear: {
+    id: 'clear',
+    title: 'Clear index and rebuild?',
+    consequences: [
+      'Deletes your browsing-history index',
+      'Immediately rebuilds it from browser history',
+      'Your settings are NOT changed',
+    ],
+    confirmLabel: 'Clear & rebuild',
+    undoable: true,
+  },
+  factoryReset: {
+    id: 'factoryReset',
+    title: 'Factory reset the extension?',
+    consequences: [
+      'Resets ALL settings to defaults',
+      'Clears ALL indexed data and caches',
+      'Rebuilds the index from your browser history',
+    ],
+    confirmLabel: 'Factory reset',
+    undoable: true,
+  },
+};
+
+export function describeOp(id: DestructiveOpId): DestructiveOp {
+  return DESTRUCTIVE_OPS[id];
+}
+
+/** A snapshot is restorable only if it is a (possibly empty) array of items. */
+export function isSnapshotRestorable(items: unknown): items is unknown[] {
+  return Array.isArray(items);
+}
+
+export interface UndoableDeps<T> {
+  /** Capture state before the op. Return null if a snapshot can't be taken. */
+  snapshot: () => Promise<T | null>;
+  /** Perform the destructive op. Resolve true on success. */
+  run: () => Promise<boolean>;
+  /** Restore a previously-captured snapshot (the undo action). */
+  restore: (snap: T) => Promise<void>;
+  /** Present the undo affordance to the user (e.g. a toast with an Undo button). */
+  offerUndo: (undo: () => void) => void;
+}
+
+/**
+ * Snapshot → run → offer undo. The undo affordance is only offered when the op
+ * succeeded AND a snapshot was captured (otherwise there is nothing safe to undo).
+ * A failing snapshot never blocks the op — recovery is best-effort.
+ *
+ * @returns whatever `run()` resolved (success boolean).
+ */
+export async function runWithUndo<T>(deps: UndoableDeps<T>): Promise<boolean> {
+  let snap: T | null = null;
+  try {
+    snap = await deps.snapshot();
+  } catch {
+    snap = null;
+  }
+
+  const ok = await deps.run();
+
+  if (ok && snap !== null) {
+    const captured = snap;
+    deps.offerUndo(() => {
+      void deps.restore(captured);
+    });
+  }
+  return ok;
+}

--- a/src/shared/__tests__/web-search.test.ts
+++ b/src/shared/__tests__/web-search.test.ts
@@ -91,6 +91,33 @@ describe('web-search parseWebSearchQuery', () => {
       matchedPrefix: 'gc',
     });
   });
+
+  it('matches uppercase prefix case-insensitively (J → jira)', () => {
+    expect(parseWebSearchQuery('J PROJ-1', 'google')).toEqual({
+      engineKey: 'jira',
+      searchTerms: 'PROJ-1',
+      usedPrefix: true,
+      matchedPrefix: 'j',
+    });
+  });
+
+  it('matches mixed-case multi-char prefix (GH) and preserves term case', () => {
+    expect(parseWebSearchQuery('GH MyRepo', 'google')).toEqual({
+      engineKey: 'github',
+      searchTerms: 'MyRepo',
+      usedPrefix: true,
+      matchedPrefix: 'gh',
+    });
+  });
+
+  it('matches prefix-only uppercase Y as YouTube', () => {
+    expect(parseWebSearchQuery('Y', 'google')).toEqual({
+      engineKey: 'youtube',
+      searchTerms: '',
+      usedPrefix: true,
+      matchedPrefix: 'y',
+    });
+  });
 });
 
 describe('web-search buildWebSearchUrl', () => {

--- a/src/shared/command-registry.ts
+++ b/src/shared/command-registry.ts
@@ -508,6 +508,16 @@ const EVERYDAY_COMMANDS: PaletteCommand[] = [
         messageType: 'OPEN_SETTINGS',
     },
     {
+        id: 'welcome',
+        label: 'Open Welcome / Onboarding',
+        icon: '👋',
+        tier: 'everyday',
+        category: 'navigation',
+        keywords: ['welcome', 'onboarding', 'guide', 'getting started', 'intro', 'learn', 'help'],
+        action: 'message',
+        messageType: 'OPEN_WELCOME',
+    },
+    {
         id: 'tour',
         label: 'Open Feature Tour',
         icon: '📖',

--- a/src/shared/onboarding/__tests__/cheatsheet.test.ts
+++ b/src/shared/onboarding/__tests__/cheatsheet.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { buildCheatsheetSections, PALETTE_MODES, KEYBOARD_SHORTCUTS } from '../cheatsheet';
+import { SEARCH_ENGINE_PREFIXES } from '../../web-search';
+
+describe('buildCheatsheetSections', () => {
+  it('returns palette, web, shortcuts and omnibox sections in order', () => {
+    const sections = buildCheatsheetSections();
+    expect(sections.map((s) => s.id)).toEqual(['palette', 'web', 'shortcuts', 'omnibox']);
+  });
+
+  it('includes every web-search prefix from web-search.ts (single source, no duplicate)', () => {
+    const web = buildCheatsheetSections().find((s) => s.id === 'web');
+    expect(web).toBeDefined();
+    const keys = web!.entries.map((e) => e.keys);
+    for (const prefix of Object.keys(SEARCH_ENGINE_PREFIXES)) {
+      expect(keys).toContain(`?? ${prefix}`);
+    }
+  });
+
+  it('marks all modes enabled when no enabledModes given', () => {
+    const palette = buildCheatsheetSections().find((s) => s.id === 'palette')!;
+    expect(palette.entries.every((e) => e.enabled === true)).toBe(true);
+  });
+
+  it('reflects enabledModes for configurable modes; ? help stays always-on', () => {
+    const palette = buildCheatsheetSections({ enabledModes: ['/', '@'] }).find((s) => s.id === 'palette')!;
+    const byKeys = Object.fromEntries(palette.entries.map((e) => [e.keys, e.enabled]));
+    expect(byKeys['/']).toBe(true);
+    expect(byKeys['@']).toBe(true);
+    expect(byKeys['#']).toBe(false);
+    expect(byKeys['??']).toBe(false);
+    expect(byKeys['>']).toBe(false);
+    expect(byKeys['?']).toBe(true); // help is not a configurable mode — always available
+  });
+
+  it('flags the > power mode as advanced', () => {
+    const palette = buildCheatsheetSections().find((s) => s.id === 'palette')!;
+    const power = palette.entries.find((e) => e.keys === '>')!;
+    expect(power.advanced).toBe(true);
+  });
+
+  it('leads keyboard shortcuts with Ctrl+Shift+S and exposes the / palette mode', () => {
+    expect(KEYBOARD_SHORTCUTS[0]!.keys).toBe('Ctrl+Shift+S');
+    expect(PALETTE_MODES.some((m) => m.keys === '/')).toBe(true);
+  });
+});

--- a/src/shared/onboarding/__tests__/checklist.test.ts
+++ b/src/shared/onboarding/__tests__/checklist.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { chromeMock } from '../../../__test-utils__';
+
+const mocks = vi.hoisted(() => ({ settings: {} as Record<string, unknown> }));
+
+vi.mock('../../../core/settings', () => ({
+  SettingsManager: {
+    getSetting: (k: string) => mocks.settings[k],
+    init: () => Promise.resolve(),
+  },
+}));
+
+import { initChecklist } from '../checklist';
+
+const ALL_DONE = {
+  onboardingMilestones: {
+    firstSearch: true,
+    firstResultOpen: true,
+    firstSlashCommand: true,
+    firstWebSearch: true,
+    firstOverlayOpen: true,
+  },
+};
+
+describe('onboarding checklist (Silo A)', () => {
+  let get: Mock;
+  let set: Mock;
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.settings = { onboardingEnabled: true, onboardingChecklistEnabled: true };
+    const chromeApi = chromeMock().withStorage().build();
+    get = chromeApi.storage!.local.get as Mock;
+    set = chromeApi.storage!.local.set as Mock;
+    get.mockImplementation(() => Promise.resolve({})); // not dismissed, no milestones
+    set.mockResolvedValue(undefined);
+    vi.stubGlobal('chrome', chromeApi);
+    container = document.createElement('div');
+  });
+
+  it('renders when enabled, not dismissed, and not all done', async () => {
+    const rendered = await initChecklist(container);
+    expect(rendered).toBe(true);
+    expect(container.querySelector('.onboarding-checklist')).not.toBeNull();
+    expect(container.querySelectorAll('.onboarding-checklist__item').length).toBe(5);
+  });
+
+  it('marks completed steps and shows a progress count', async () => {
+    get.mockImplementation((key: string) =>
+      Promise.resolve(key === 'onboardingMilestones' ? { onboardingMilestones: { firstSearch: true } } : {}),
+    );
+    await initChecklist(container);
+    expect(container.querySelectorAll('.onboarding-checklist__item.is-done').length).toBe(1);
+    expect(container.querySelector('.onboarding-checklist__title')?.textContent).toContain('1/5');
+  });
+
+  it('is a no-op when the silo flag is off', async () => {
+    mocks.settings.onboardingChecklistEnabled = false;
+    const rendered = await initChecklist(container);
+    expect(rendered).toBe(false);
+    expect(container.querySelector('.onboarding-checklist')).toBeNull();
+  });
+
+  it('is a no-op when the master flag is off', async () => {
+    mocks.settings.onboardingEnabled = false;
+    expect(await initChecklist(container)).toBe(false);
+  });
+
+  it('does not render once all milestones are complete', async () => {
+    get.mockImplementation((key: string) =>
+      Promise.resolve(key === 'onboardingMilestones' ? ALL_DONE : {}),
+    );
+    expect(await initChecklist(container)).toBe(false);
+  });
+
+  it('does not render when previously dismissed', async () => {
+    get.mockImplementation((key: string) =>
+      Promise.resolve(key === 'onboardingChecklistDismissed' ? { onboardingChecklistDismissed: true } : {}),
+    );
+    expect(await initChecklist(container)).toBe(false);
+  });
+
+  it('dismiss button stores the flag and clears the card', async () => {
+    await initChecklist(container);
+    const close = container.querySelector('.onboarding-checklist__close') as HTMLButtonElement;
+    expect(close).not.toBeNull();
+    close.click();
+    expect(set).toHaveBeenCalledWith({ onboardingChecklistDismissed: true });
+    expect(container.querySelector('.onboarding-checklist')).toBeNull();
+  });
+
+  it('returns false for a null container', async () => {
+    expect(await initChecklist(null)).toBe(false);
+  });
+});

--- a/src/shared/onboarding/__tests__/demos.test.ts
+++ b/src/shared/onboarding/__tests__/demos.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { mountDemos, buildDemoElement, DEMO_DEFINITIONS } from '../demos';
+
+describe('onboarding demos (Silo D)', () => {
+  it('buildDemoElement renders title, typed text, caret and caption', () => {
+    const el = buildDemoElement({ id: 'x', title: 'Title', typed: 'hello', caption: 'Cap' });
+    expect(el.classList.contains('w-demo')).toBe(true);
+    expect(el.dataset.demoId).toBe('x');
+    expect(el.querySelector('.w-demo__title')?.textContent).toBe('Title');
+    expect(el.querySelector('.w-demo__stage')?.textContent).toContain('hello');
+    expect(el.querySelector('.w-demo__caption')?.textContent).toBe('Cap');
+    expect(el.querySelector('.w-demo__caret')).not.toBeNull();
+  });
+
+  it('mountDemos injects one card per definition by default', () => {
+    const container = document.createElement('div');
+    expect(mountDemos(container)).toBe(true);
+    expect(container.querySelectorAll('.w-demo').length).toBe(DEMO_DEFINITIONS.length);
+  });
+
+  it('mountDemos renders custom definitions when provided', () => {
+    const container = document.createElement('div');
+    mountDemos(container, { defs: [{ id: 'only', title: 'T', typed: 'q', caption: 'c' }] });
+    expect(container.querySelectorAll('.w-demo').length).toBe(1);
+  });
+
+  it('is a no-op and tears down the grid when enabled is false', () => {
+    const container = document.createElement('div');
+    mountDemos(container);
+    expect(mountDemos(container, { enabled: false })).toBe(false);
+    expect(container.querySelector('.w-demos')).toBeNull();
+  });
+
+  it('is idempotent — re-mounting does not duplicate the grid', () => {
+    const container = document.createElement('div');
+    mountDemos(container);
+    mountDemos(container);
+    expect(container.querySelectorAll('.w-demos').length).toBe(1);
+  });
+
+  it('returns false for a null container', () => {
+    expect(mountDemos(null)).toBe(false);
+  });
+});

--- a/src/shared/onboarding/__tests__/milestones.test.ts
+++ b/src/shared/onboarding/__tests__/milestones.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { chromeMock } from '../../../__test-utils__';
+import {
+  CHECKLIST_STEPS,
+  isComplete,
+  completedCount,
+  allComplete,
+  withMilestone,
+  getMilestones,
+  markMilestone,
+  resetMilestones,
+  type MilestoneState,
+} from '../milestones';
+
+describe('milestones — pure state queries', () => {
+  it('isComplete reflects the flag', () => {
+    expect(isComplete({ firstSearch: true }, 'firstSearch')).toBe(true);
+    expect(isComplete({}, 'firstSearch')).toBe(false);
+  });
+
+  it('completedCount counts only completed steps', () => {
+    expect(completedCount({})).toBe(0);
+    expect(completedCount({ firstSearch: true, firstResultOpen: true })).toBe(2);
+  });
+
+  it('allComplete is true only when every step is done', () => {
+    const all: MilestoneState = {};
+    for (const step of CHECKLIST_STEPS) { all[step.id] = true; }
+    expect(allComplete(all)).toBe(true);
+    expect(allComplete({ firstSearch: true })).toBe(false);
+  });
+
+  it('withMilestone returns a new state without mutating the original', () => {
+    const state: MilestoneState = {};
+    const next = withMilestone(state, 'firstSearch');
+    expect(next.firstSearch).toBe(true);
+    expect(state.firstSearch).toBeUndefined();
+  });
+
+  it('withMilestone returns the same reference when already set (no-op)', () => {
+    const state: MilestoneState = { firstSearch: true };
+    expect(withMilestone(state, 'firstSearch')).toBe(state);
+  });
+});
+
+describe('milestones — storage I/O', () => {
+  let get: Mock;
+  let set: Mock;
+  let remove: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chromeApi = chromeMock().withStorage().build();
+    get = chromeApi.storage!.local.get as Mock;
+    set = chromeApi.storage!.local.set as Mock;
+    remove = chromeApi.storage!.local.remove as Mock;
+    get.mockResolvedValue({});
+    set.mockResolvedValue(undefined);
+    remove.mockResolvedValue(undefined);
+    vi.stubGlobal('chrome', chromeApi);
+  });
+
+  it('getMilestones returns {} when storage is empty', async () => {
+    await expect(getMilestones()).resolves.toEqual({});
+  });
+
+  it('getMilestones returns the stored state', async () => {
+    get.mockResolvedValueOnce({ onboardingMilestones: { firstSearch: true } });
+    await expect(getMilestones()).resolves.toEqual({ firstSearch: true });
+  });
+
+  it('getMilestones returns {} on storage error', async () => {
+    get.mockRejectedValueOnce(new Error('storage fail'));
+    await expect(getMilestones()).resolves.toEqual({});
+  });
+
+  it('markMilestone persists a newly-reached milestone', async () => {
+    await markMilestone('firstSearch');
+    expect(set).toHaveBeenCalledWith({ onboardingMilestones: { firstSearch: true } });
+  });
+
+  it('markMilestone is idempotent — no write when already set', async () => {
+    get.mockResolvedValueOnce({ onboardingMilestones: { firstSearch: true } });
+    await markMilestone('firstSearch');
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('markMilestone swallows storage errors', async () => {
+    set.mockRejectedValueOnce(new Error('storage fail'));
+    await expect(markMilestone('firstSearch')).resolves.toBeUndefined();
+  });
+
+  it('resetMilestones removes the storage key', async () => {
+    await resetMilestones();
+    expect(remove).toHaveBeenCalledWith('onboardingMilestones');
+  });
+});

--- a/src/shared/onboarding/__tests__/tips.test.ts
+++ b/src/shared/onboarding/__tests__/tips.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { chromeMock } from '../../../__test-utils__';
+import {
+  PALETTE_TIP_ID,
+  TIP_DEFINITIONS,
+  DEFAULT_TIP_POLICY,
+  areTipsEnabled,
+  shouldShowTip,
+  getTipState,
+  recordTipShown,
+  resetTips,
+} from '../tips';
+
+describe('tips — gating', () => {
+  it('areTipsEnabled requires both master and silo flags', () => {
+    expect(areTipsEnabled({ onboardingEnabled: true, onboardingTipsEnabled: true })).toBe(true);
+    expect(areTipsEnabled({ onboardingEnabled: false, onboardingTipsEnabled: true })).toBe(false);
+    expect(areTipsEnabled({ onboardingEnabled: true, onboardingTipsEnabled: false })).toBe(false);
+    expect(areTipsEnabled(null)).toBe(false);
+    expect(areTipsEnabled(undefined)).toBe(false);
+  });
+
+  it('treats undefined flags as enabled (default-on)', () => {
+    expect(areTipsEnabled({})).toBe(true);
+  });
+});
+
+describe('tips — shouldShowTip (replayable, not a one-shot)', () => {
+  const NOW = 1_000_000_000_000;
+  const { maxShows, cooldownMs } = DEFAULT_TIP_POLICY;
+
+  it('shows when there is no record yet', () => {
+    expect(shouldShowTip(undefined, NOW)).toBe(true);
+  });
+
+  it('does not re-show within the cooldown window', () => {
+    expect(shouldShowTip({ lastShown: NOW, count: 1 }, NOW + cooldownMs - 1)).toBe(false);
+  });
+
+  it('re-shows once the cooldown has elapsed', () => {
+    expect(shouldShowTip({ lastShown: NOW, count: 1 }, NOW + cooldownMs)).toBe(true);
+  });
+
+  it('stops showing after maxShows (bounded replay — the fix vs the old permanent latch)', () => {
+    expect(shouldShowTip({ lastShown: NOW, count: maxShows }, NOW + cooldownMs * 10)).toBe(false);
+  });
+});
+
+describe('tips — storage I/O', () => {
+  let get: Mock;
+  let set: Mock;
+  let remove: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const chromeApi = chromeMock().withStorage().build();
+    get = chromeApi.storage!.local.get as Mock;
+    set = chromeApi.storage!.local.set as Mock;
+    remove = chromeApi.storage!.local.remove as Mock;
+    get.mockResolvedValue({});
+    set.mockResolvedValue(undefined);
+    remove.mockResolvedValue(undefined);
+    vi.stubGlobal('chrome', chromeApi);
+  });
+
+  it('getTipState returns {} when empty', async () => {
+    await expect(getTipState()).resolves.toEqual({});
+  });
+
+  it('recordTipShown initialises a record with count 1', async () => {
+    await recordTipShown(PALETTE_TIP_ID, 5000);
+    expect(set).toHaveBeenCalledWith({ onboardingTipState: { [PALETTE_TIP_ID]: { lastShown: 5000, count: 1 } } });
+  });
+
+  it('recordTipShown increments an existing count', async () => {
+    get.mockResolvedValueOnce({ onboardingTipState: { [PALETTE_TIP_ID]: { lastShown: 1, count: 2 } } });
+    await recordTipShown(PALETTE_TIP_ID, 9000);
+    expect(set).toHaveBeenCalledWith({ onboardingTipState: { [PALETTE_TIP_ID]: { lastShown: 9000, count: 3 } } });
+  });
+
+  it('recordTipShown swallows storage errors', async () => {
+    set.mockRejectedValueOnce(new Error('storage fail'));
+    await expect(recordTipShown(PALETTE_TIP_ID, 1)).resolves.toBeUndefined();
+  });
+
+  it('resetTips removes the storage key (tips become showable again)', async () => {
+    await resetTips();
+    expect(remove).toHaveBeenCalledWith('onboardingTipState');
+  });
+
+  it('the palette tip message is defined and mentions the / prefix', () => {
+    expect(TIP_DEFINITIONS[PALETTE_TIP_ID]?.message).toContain('/');
+  });
+});

--- a/src/shared/onboarding/cheatsheet.ts
+++ b/src/shared/onboarding/cheatsheet.ts
@@ -1,0 +1,84 @@
+// cheatsheet.ts — the ONE data builder for "here's everything you can do".
+//
+// Pure, dependency-light, framework-free. Feeds three surfaces from a single source:
+//   • the welcome page (Phase 2)
+//   • the in-extension `?` help panel in quick-search + popup (Phase 5)
+//   • (potential) docs
+// Web-search engine rows are derived from src/shared/web-search.ts so there is no
+// hand-maintained duplicate of the prefix list.
+
+import { getWebSearchPrefixHintLines } from '../web-search';
+
+/** A single "do this → get that" row. */
+export interface CheatsheetEntry {
+  /** The literal keys/prefix the user types, e.g. "Ctrl+Shift+S", "/", "?? g". */
+  keys: string;
+  /** Plain-language description of what it does. */
+  label: string;
+  /** True for advanced/opt-in capabilities we surface but de-emphasise. */
+  advanced?: boolean;
+  /** Reflects whether a configurable palette mode is currently turned on. */
+  enabled?: boolean;
+}
+
+export interface CheatsheetSection {
+  id: string;
+  title: string;
+  entries: CheatsheetEntry[];
+}
+
+/** Palette prefixes. The five configurable modes + the always-on `?` help. */
+export const PALETTE_MODES: CheatsheetEntry[] = [
+  { keys: '/', label: 'Commands — flip settings and run quick actions' },
+  { keys: '@', label: 'Tabs — jump straight to any open tab' },
+  { keys: '#', label: 'Bookmarks — search your bookmarks' },
+  { keys: '??', label: 'Web — search Google, YouTube, GitHub and more' },
+  { keys: '?', label: 'Help — show this cheatsheet' },
+  { keys: '>', label: 'Power — advanced browser commands (opt-in)', advanced: true },
+];
+
+/** The configurable palette modes (mirror SETTINGS_SCHEMA.commandPaletteModes). `?` is always on. */
+const CONFIGURABLE_MODES = ['/', '>', '@', '#', '??'];
+
+/** Keyboard shortcuts, in the order most useful to learn. */
+export const KEYBOARD_SHORTCUTS: CheatsheetEntry[] = [
+  { keys: 'Ctrl+Shift+S', label: 'Open search on any page' },
+  { keys: 'Enter', label: 'Open the highlighted result' },
+  { keys: 'Shift+Enter', label: 'Open in a background tab' },
+  { keys: '↑ / ↓', label: 'Move between results' },
+  { keys: 'Esc', label: 'Clear the box / close the overlay' },
+  { keys: 'Ctrl+C', label: 'Copy the result as a link' },
+  { keys: 'Ctrl+M', label: 'Copy the result as Markdown' },
+];
+
+/**
+ * Build the full cheatsheet as ordered sections.
+ *
+ * @param opts.enabledModes - when provided, configurable palette modes are marked
+ *   enabled/disabled to match the user's settings. `?` help is always enabled.
+ */
+export function buildCheatsheetSections(opts: { enabledModes?: string[] } = {}): CheatsheetSection[] {
+  const { enabledModes } = opts;
+
+  const paletteEntries: CheatsheetEntry[] = PALETTE_MODES.map((entry) => {
+    const configurable = CONFIGURABLE_MODES.includes(entry.keys);
+    const enabled = enabledModes && configurable ? enabledModes.includes(entry.keys) : true;
+    return { ...entry, enabled };
+  });
+
+  const webEntries: CheatsheetEntry[] = getWebSearchPrefixHintLines().map((line) => ({
+    keys: `?? ${line.prefix}`,
+    label: line.engineLabel,
+  }));
+
+  return [
+    { id: 'palette', title: 'Type a prefix to switch modes', entries: paletteEntries },
+    { id: 'web', title: 'Search the web fast', entries: webEntries },
+    { id: 'shortcuts', title: 'Keyboard shortcuts', entries: KEYBOARD_SHORTCUTS },
+    {
+      id: 'omnibox',
+      title: 'From the address bar',
+      entries: [{ keys: 'sc ', label: 'Type "sc" then Space in the address bar, then your search' }],
+    },
+  ];
+}

--- a/src/shared/onboarding/checklist.ts
+++ b/src/shared/onboarding/checklist.ts
@@ -1,0 +1,118 @@
+// checklist.ts — Silo A: the learn-by-doing onboarding checklist card (popup only).
+//
+// Independently toggleable: initChecklist no-ops unless BOTH onboardingEnabled and
+// onboardingChecklistEnabled are true. "Dismissed" is stored separately from
+// milestone progress, so closing the card never loses progress. Remove this silo by
+// deleting this file, its one initChecklist() call in popup.ts, the milestone marks,
+// the #onboarding-checklist mount node, and the onboardingChecklistEnabled flag.
+
+import { Logger, errorMeta } from '../../core/logger';
+import { SettingsManager } from '../../core/settings';
+import {
+  CHECKLIST_STEPS,
+  getMilestones,
+  allComplete,
+  completedCount,
+  type MilestoneState,
+} from './milestones';
+
+const log = Logger.forComponent('OnboardingChecklist');
+const DISMISS_KEY = 'onboardingChecklistDismissed';
+
+function isChecklistEnabled(): boolean {
+  return (
+    SettingsManager.getSetting('onboardingEnabled') !== false &&
+    SettingsManager.getSetting('onboardingChecklistEnabled') !== false
+  );
+}
+
+async function isDismissed(): Promise<boolean> {
+  try {
+    const r = await chrome.storage.local.get(DISMISS_KEY);
+    return r[DISMISS_KEY] === true;
+  } catch {
+    return false;
+  }
+}
+
+async function setDismissed(): Promise<void> {
+  try {
+    await chrome.storage.local.set({ [DISMISS_KEY]: true });
+  } catch {
+    // non-critical
+  }
+}
+
+function render(container: HTMLElement, state: MilestoneState, onDismiss: () => void): void {
+  container.replaceChildren();
+
+  const card = document.createElement('div');
+  card.className = 'onboarding-checklist';
+
+  const head = document.createElement('div');
+  head.className = 'onboarding-checklist__head';
+  const title = document.createElement('span');
+  title.className = 'onboarding-checklist__title';
+  title.textContent = `Getting started (${completedCount(state)}/${CHECKLIST_STEPS.length})`;
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'onboarding-checklist__close';
+  close.title = 'Dismiss';
+  close.setAttribute('aria-label', 'Dismiss the getting-started checklist');
+  close.textContent = '✕';
+  close.addEventListener('click', onDismiss);
+  head.append(title, close);
+  card.appendChild(head);
+
+  const list = document.createElement('ul');
+  list.className = 'onboarding-checklist__list';
+  for (const step of CHECKLIST_STEPS) {
+    const done = state[step.id] === true;
+    const li = document.createElement('li');
+    li.className = done ? 'onboarding-checklist__item is-done' : 'onboarding-checklist__item';
+    const mark = document.createElement('span');
+    mark.className = 'onboarding-checklist__mark';
+    mark.textContent = done ? '✓' : '○';
+    const label = document.createElement('span');
+    label.className = 'onboarding-checklist__label';
+    label.textContent = step.label;
+    label.title = step.hint;
+    li.append(mark, label);
+    list.appendChild(li);
+  }
+  card.appendChild(list);
+  container.appendChild(card);
+}
+
+/**
+ * Render the checklist into `container` when appropriate. Safe no-op (and clears the
+ * container) when the silo is off, the card was dismissed, or every step is done.
+ *
+ * @returns true if the checklist was rendered.
+ */
+export async function initChecklist(container: HTMLElement | null): Promise<boolean> {
+  if (!container) { return false; }
+  if (!isChecklistEnabled()) {
+    container.replaceChildren();
+    return false;
+  }
+  try {
+    if (await isDismissed()) {
+      container.replaceChildren();
+      return false;
+    }
+    const state = await getMilestones();
+    if (allComplete(state)) {
+      container.replaceChildren();
+      return false;
+    }
+    render(container, state, () => {
+      void setDismissed();
+      container.replaceChildren();
+    });
+    return true;
+  } catch (err) {
+    log.warn('initChecklist', 'Failed to render onboarding checklist', errorMeta(err));
+    return false;
+  }
+}

--- a/src/shared/onboarding/demos.ts
+++ b/src/shared/onboarding/demos.ts
@@ -1,0 +1,71 @@
+// demos.ts — Silo D: small looping demos embedded on the welcome page.
+//
+// Pure DOM builders (no settings, no chrome) so they're trivially testable; the
+// welcome page gates them on onboardingDemosEnabled. Animation is CSS-driven
+// (keyframes live in welcome.css) and respects prefers-reduced-motion.
+
+export interface DemoDefinition {
+  id: string;
+  title: string;
+  /** Text shown "in the search box" with a blinking caret. */
+  typed: string;
+  /** One-line plain-language explanation of the action. */
+  caption: string;
+}
+
+export const DEMO_DEFINITIONS: DemoDefinition[] = [
+  { id: 'overlay', title: 'Search instantly', typed: 'react hooks', caption: 'Press Ctrl+Shift+S, type, hit Enter.' },
+  { id: 'commands', title: 'Run a command', typed: '/ dark mode', caption: 'Type / to flip settings and run quick actions.' },
+  { id: 'websearch', title: 'Search the web', typed: '?? g typescript enums', caption: 'Type ?? then your query — g for Google, gh for GitHub…' },
+];
+
+/** Build one demo card. Pure — returns a detached element. */
+export function buildDemoElement(def: DemoDefinition): HTMLElement {
+  const card = document.createElement('div');
+  card.className = 'w-demo';
+  card.dataset.demoId = def.id;
+
+  const title = document.createElement('p');
+  title.className = 'w-demo__title';
+  title.textContent = def.title;
+
+  const stage = document.createElement('div');
+  stage.className = 'w-demo__stage';
+  const typed = document.createElement('span');
+  typed.textContent = def.typed;
+  const caret = document.createElement('span');
+  caret.className = 'w-demo__caret';
+  caret.textContent = '▋';
+  stage.append(typed, caret);
+
+  const caption = document.createElement('p');
+  caption.className = 'w-demo__caption';
+  caption.textContent = def.caption;
+
+  card.append(title, stage, caption);
+  return card;
+}
+
+/**
+ * Mount the demo grid into `container`. Idempotent (replaces any prior grid).
+ *
+ * @param opts.enabled - when false, tears the grid down and returns false (the
+ *   onboardingDemosEnabled gate is applied by the caller).
+ * @returns true if demos were mounted.
+ */
+export function mountDemos(
+  container: HTMLElement | null,
+  opts: { enabled?: boolean; defs?: DemoDefinition[] } = {},
+): boolean {
+  if (!container) { return false; }
+  container.querySelector('.w-demos')?.remove(); // idempotent re-mount / teardown
+  if (opts.enabled === false) { return false; }
+
+  const grid = document.createElement('div');
+  grid.className = 'w-demos';
+  for (const def of opts.defs ?? DEMO_DEFINITIONS) {
+    grid.appendChild(buildDemoElement(def));
+  }
+  container.appendChild(grid);
+  return true;
+}

--- a/src/shared/onboarding/milestones.ts
+++ b/src/shared/onboarding/milestones.ts
@@ -1,0 +1,81 @@
+// milestones.ts — tracks a new user's first key actions for the onboarding checklist
+// (Silo A). Pure state queries + thin chrome.storage.local I/O (mirrors
+// recent-searches.ts). No DOM — safe to import from popup AND quick-search.
+
+export type MilestoneId =
+  | 'firstSearch'
+  | 'firstResultOpen'
+  | 'firstSlashCommand'
+  | 'firstWebSearch'
+  | 'firstOverlayOpen';
+
+export interface ChecklistStep {
+  id: MilestoneId;
+  label: string;
+  hint: string;
+}
+
+/** The checklist, in the order a new user naturally discovers each capability. */
+export const CHECKLIST_STEPS: ChecklistStep[] = [
+  { id: 'firstSearch', label: 'Run your first search', hint: 'Type anything to search your history.' },
+  { id: 'firstResultOpen', label: 'Open a result', hint: 'Press Enter or click a result.' },
+  { id: 'firstSlashCommand', label: 'Try a / command', hint: 'Type / to flip settings and run quick actions.' },
+  { id: 'firstWebSearch', label: 'Search the web with ??', hint: 'Type ?? then your query.' },
+  { id: 'firstOverlayOpen', label: 'Open the quick-search overlay', hint: 'Press Ctrl+Shift+S on any page.' },
+];
+
+export type MilestoneState = Partial<Record<MilestoneId, boolean>>;
+
+const STORAGE_KEY = 'onboardingMilestones';
+
+// ── Pure state queries (unit-tested directly) ──────────────────────────────
+
+export function isComplete(state: MilestoneState, id: MilestoneId): boolean {
+  return state[id] === true;
+}
+
+export function completedCount(state: MilestoneState): number {
+  return CHECKLIST_STEPS.reduce((n, step) => (state[step.id] ? n + 1 : n), 0);
+}
+
+export function allComplete(state: MilestoneState): boolean {
+  return CHECKLIST_STEPS.every((step) => state[step.id] === true);
+}
+
+/** Pure: returns a NEW state with `id` marked complete (no mutation). */
+export function withMilestone(state: MilestoneState, id: MilestoneId): MilestoneState {
+  if (state[id]) { return state; }
+  return { ...state, [id]: true };
+}
+
+// ── Thin chrome.storage.local I/O ──────────────────────────────────────────
+
+export async function getMilestones(): Promise<MilestoneState> {
+  try {
+    const result = await chrome.storage.local.get(STORAGE_KEY);
+    const state = result[STORAGE_KEY];
+    if (state && typeof state === 'object') { return state as MilestoneState; }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/** Mark a milestone complete. Idempotent and fire-and-forget safe. */
+export async function markMilestone(id: MilestoneId): Promise<void> {
+  try {
+    const state = await getMilestones();
+    if (state[id]) { return; }
+    await chrome.storage.local.set({ [STORAGE_KEY]: withMilestone(state, id) });
+  } catch {
+    // Silently fail — onboarding progress is non-critical.
+  }
+}
+
+export async function resetMilestones(): Promise<void> {
+  try {
+    await chrome.storage.local.remove(STORAGE_KEY);
+  } catch {
+    // Silently fail.
+  }
+}

--- a/src/shared/onboarding/tips.ts
+++ b/src/shared/onboarding/tips.ts
@@ -1,0 +1,90 @@
+// tips.ts — Silo B: replayable just-in-time "Did you know?" tips.
+//
+// Fixes the old "shown once, lost forever" latch (commandPaletteOnboarded): instead
+// of a permanent boolean, each tip is shown up to `maxShows` times on a cooldown and
+// can be reset. Pure policy (shouldShowTip) + thin chrome.storage I/O. Gated by
+// onboardingEnabled (master) + onboardingTipsEnabled. No DOM here — callers render.
+
+import type { AppSettings } from '../../core/settings';
+
+export interface TipDefinition {
+  id: string;
+  message: string;
+}
+
+/** The palette-intro tip (the copy the old one-shot first-use hint used). */
+export const PALETTE_TIP_ID = 'paletteIntro';
+
+export const TIP_DEFINITIONS: Record<string, TipDefinition> = {
+  [PALETTE_TIP_ID]: {
+    id: PALETTE_TIP_ID,
+    message: 'New: Type / for commands, @ for tabs, # for bookmarks, ?? for web',
+  },
+};
+
+export interface TipRecord {
+  lastShown: number;
+  count: number;
+}
+export type TipState = Record<string, TipRecord>;
+
+export interface TipPolicy {
+  maxShows: number;
+  cooldownMs: number;
+}
+export const DEFAULT_TIP_POLICY: TipPolicy = {
+  maxShows: 3,
+  cooldownMs: 3 * 24 * 60 * 60 * 1000, // re-show at most once every 3 days
+};
+
+type OnboardingFlags = Pick<AppSettings, 'onboardingEnabled' | 'onboardingTipsEnabled'>;
+
+/** Master + silo gate. */
+export function areTipsEnabled(settings: OnboardingFlags | null | undefined): boolean {
+  if (!settings) { return false; }
+  return settings.onboardingEnabled !== false && settings.onboardingTipsEnabled !== false;
+}
+
+/** Pure: may this tip be shown now, given its record and the policy? */
+export function shouldShowTip(
+  record: TipRecord | undefined,
+  now: number,
+  policy: TipPolicy = DEFAULT_TIP_POLICY,
+): boolean {
+  if (!record) { return true; }
+  if (record.count >= policy.maxShows) { return false; }
+  return now - record.lastShown >= policy.cooldownMs;
+}
+
+const STORAGE_KEY = 'onboardingTipState';
+
+export async function getTipState(): Promise<TipState> {
+  try {
+    const r = await chrome.storage.local.get(STORAGE_KEY);
+    const s = r[STORAGE_KEY];
+    if (s && typeof s === 'object') { return s as TipState; }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/** Record that a tip was shown now: bumps count + lastShown (replayable, not a latch). */
+export async function recordTipShown(id: string, now: number = Date.now()): Promise<void> {
+  try {
+    const state = await getTipState();
+    const prev = state[id];
+    const next: TipRecord = { lastShown: now, count: (prev?.count ?? 0) + 1 };
+    await chrome.storage.local.set({ [STORAGE_KEY]: { ...state, [id]: next } });
+  } catch {
+    // non-critical
+  }
+}
+
+export async function resetTips(): Promise<void> {
+  try {
+    await chrome.storage.local.remove(STORAGE_KEY);
+  } catch {
+    // non-critical
+  }
+}

--- a/src/shared/web-search.ts
+++ b/src/shared/web-search.ts
@@ -96,15 +96,16 @@ export function parseWebSearchQuery(query: string, defaultEngineKey: string): Pa
     if (!q) {
         return { engineKey: defaultEngineKey, searchTerms: '', usedPrefix: false };
     }
+    const qLower = q.toLowerCase();
     for (const prefix of sortedWebSearchPrefixKeys()) {
         const engineKey = SEARCH_ENGINE_PREFIXES[prefix];
         if (!engineKey) {
             continue;
         }
-        if (q === prefix) {
+        if (qLower === prefix) {
             return { engineKey, searchTerms: '', usedPrefix: true, matchedPrefix: prefix };
         }
-        if (q.startsWith(`${prefix} `)) {
+        if (qLower.startsWith(`${prefix} `)) {
             return {
                 engineKey,
                 searchTerms: q.slice(prefix.length + 1).trim(),

--- a/src/welcome/__tests__/welcome-content.test.ts
+++ b/src/welcome/__tests__/welcome-content.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { getWelcomePageModel } from '../welcome-content';
+import { SEARCH_ENGINE_PREFIXES } from '../../shared/web-search';
+
+describe('welcome-content', () => {
+  it('produces every top-level section', () => {
+    const m = getWelcomePageModel();
+    expect(m.hero.title).toMatch(/SmrutiCortex/);
+    expect(m.openWays.ways.length).toBeGreaterThanOrEqual(3);
+    expect(m.privacy.lines.length).toBeGreaterThan(0);
+    expect(m.cheatsheet.length).toBeGreaterThan(0);
+    expect(m.footer.onlineGuideUrl).toMatch(/^https:\/\//);
+  });
+
+  it('teaches the core Ctrl+Shift+S loop in the big tip', () => {
+    const m = getWelcomePageModel();
+    expect(m.bigTip.keys.replace(/\s/g, '')).toBe('Ctrl+Shift+S');
+  });
+
+  it('derives the web-search section from web-search.ts (no hand-maintained list)', () => {
+    const web = getWelcomePageModel().cheatsheet.find((s) => s.id === 'web');
+    expect(web).toBeDefined();
+    const keys = web!.entries.map((e) => e.keys);
+    for (const prefix of Object.keys(SEARCH_ENGINE_PREFIXES)) {
+      expect(keys).toContain(`?? ${prefix}`);
+    }
+  });
+
+  it('reflects disabled palette modes when enabledModes is provided', () => {
+    const palette = getWelcomePageModel(['/', '#']).cheatsheet.find((s) => s.id === 'palette')!;
+    const byKeys = Object.fromEntries(palette.entries.map((e) => [e.keys, e.enabled]));
+    expect(byKeys['/']).toBe(true);
+    expect(byKeys['#']).toBe(true);
+    expect(byKeys['@']).toBe(false);
+    expect(byKeys['?']).toBe(true); // help always on
+  });
+
+  it('includes the omnibox sc shortcut and the keyboard-shortcut section', () => {
+    const m = getWelcomePageModel();
+    expect(m.cheatsheet.find((s) => s.id === 'omnibox')).toBeDefined();
+    const shortcuts = m.cheatsheet.find((s) => s.id === 'shortcuts')!;
+    expect(shortcuts.entries.some((e) => e.keys === 'Ctrl+Shift+S')).toBe(true);
+  });
+});

--- a/src/welcome/welcome-content.ts
+++ b/src/welcome/welcome-content.ts
@@ -10,7 +10,7 @@ export const WELCOME_HERO = {
   title: 'Welcome to SmrutiCortex',
   tagline: 'Your private memory for every page you have ever visited.',
   blurb:
-    "Forgot where you read something last week? Just start typing. SmrutiCortex searches your history and bookmarks instantly — and everything stays on your own computer.",
+    'Forgot where you read something last week? Just start typing. SmrutiCortex searches your history and bookmarks instantly — and everything stays on your own computer.',
 };
 
 export const WELCOME_BIG_TIP = {

--- a/src/welcome/welcome-content.ts
+++ b/src/welcome/welcome-content.ts
@@ -1,0 +1,70 @@
+// welcome-content.ts — all the words on the welcome page, as pure data.
+//
+// Kept separate from welcome.ts (the DOM wiring) so the copy is testable and easy to
+// edit without touching rendering. Language is deliberately plain and direct.
+
+import { buildCheatsheetSections, type CheatsheetSection } from '../shared/onboarding/cheatsheet';
+
+export const WELCOME_HERO = {
+  emoji: '🌱',
+  title: 'Welcome to SmrutiCortex',
+  tagline: 'Your private memory for every page you have ever visited.',
+  blurb:
+    "Forgot where you read something last week? Just start typing. SmrutiCortex searches your history and bookmarks instantly — and everything stays on your own computer.",
+};
+
+export const WELCOME_BIG_TIP = {
+  heading: 'The one thing to remember',
+  keys: 'Ctrl + Shift + S',
+  text: 'Press this on any page to open search. That is it — you are already a power user.',
+};
+
+export const WELCOME_OPEN_WAYS = {
+  heading: 'Three ways to open it',
+  ways: [
+    'Click the SmrutiCortex icon in your browser toolbar.',
+    'Press Ctrl+Shift+S on any page to pop up the search overlay.',
+    'Type "sc" then Space in the address bar, then your search.',
+  ],
+};
+
+export const WELCOME_PRIVACY = {
+  heading: 'Your data stays yours',
+  lines: [
+    '100% on your device — nothing is ever sent to a server.',
+    'No accounts, no tracking, no cloud.',
+    'Clear or export your data anytime from Settings.',
+  ],
+};
+
+export const WELCOME_FOOTER = {
+  replayNote: 'You can reopen this guide anytime — type "welcome" in the command palette, or click the 👋 button in the popup.',
+  onlineGuideLabel: 'See the full online guide',
+  onlineGuideUrl: 'https://dhruvinrsoni.github.io/smruti-cortex/feature-tour.html',
+  privacyLabel: 'Read the privacy policy',
+  privacyUrl: 'https://dhruvinrsoni.github.io/smruti-cortex/privacy.html',
+};
+
+export interface WelcomePageModel {
+  hero: typeof WELCOME_HERO;
+  bigTip: typeof WELCOME_BIG_TIP;
+  openWays: typeof WELCOME_OPEN_WAYS;
+  cheatsheet: CheatsheetSection[];
+  privacy: typeof WELCOME_PRIVACY;
+  footer: typeof WELCOME_FOOTER;
+}
+
+/**
+ * The full welcome-page content model. Pass the user's enabled palette modes so the
+ * cheatsheet can dim the ones they have turned off.
+ */
+export function getWelcomePageModel(enabledModes?: string[]): WelcomePageModel {
+  return {
+    hero: WELCOME_HERO,
+    bigTip: WELCOME_BIG_TIP,
+    openWays: WELCOME_OPEN_WAYS,
+    cheatsheet: buildCheatsheetSections({ enabledModes }),
+    privacy: WELCOME_PRIVACY,
+    footer: WELCOME_FOOTER,
+  };
+}

--- a/src/welcome/welcome.css
+++ b/src/welcome/welcome.css
@@ -1,0 +1,113 @@
+/* welcome.css — styling for the onboarding / knowledge-transfer page.
+   Palette matches the cross-site design tokens (dark-first). */
+
+:root {
+  --bg: #0d1117;
+  --elevated: #11161d;
+  --card: #161b22;
+  --accent: #58a6ff;
+  --text: #e6edf3;
+  --muted: #8b949e;
+  --border: #2a313c;
+  --good: #3fb950;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+#welcome-root { max-width: 860px; margin: 0 auto; padding: 40px 20px 72px; }
+
+/* ── Hero ─────────────────────────────────────────────────────────────── */
+.w-hero { text-align: center; margin-bottom: 40px; }
+.w-hero__emoji { font-size: 56px; line-height: 1; }
+.w-hero__title { font-size: 32px; font-weight: 800; margin: 12px 0 4px; }
+.w-hero__tagline { font-size: 18px; color: var(--accent); margin: 0 0 12px; }
+.w-hero__blurb { font-size: 16px; color: var(--muted); max-width: 620px; margin: 0 auto; }
+
+/* ── CTA buttons ─────────────────────────────────────────────────────── */
+.w-cta { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; margin: 24px 0 8px; }
+.w-btn {
+  font: inherit; font-weight: 600; cursor: pointer;
+  padding: 11px 20px; border-radius: 10px; border: 1px solid var(--border);
+  background: var(--card); color: var(--text); transition: transform .08s ease, border-color .15s ease;
+}
+.w-btn:hover { border-color: var(--accent); transform: translateY(-1px); }
+.w-btn--primary { background: var(--accent); border-color: var(--accent); color: #0b1220; }
+.w-cta__hint { text-align: center; color: var(--muted); font-size: 13px; min-height: 18px; margin-top: 6px; }
+
+/* ── Generic card ────────────────────────────────────────────────────── */
+.w-card {
+  background: var(--card); border: 1px solid var(--border);
+  border-radius: 14px; padding: 22px 24px; margin: 18px 0;
+}
+.w-card__heading { font-size: 18px; font-weight: 700; margin: 0 0 14px; }
+
+/* ── Big "one thing to remember" tip ─────────────────────────────────── */
+.w-bigtip { text-align: center; border-color: var(--accent); }
+.w-bigtip__keys {
+  display: inline-block; font-size: 26px; font-weight: 800; letter-spacing: .5px;
+  padding: 10px 18px; margin: 4px 0 10px; border-radius: 12px;
+  background: var(--elevated); border: 1px solid var(--accent); color: var(--accent);
+}
+.w-bigtip__text { color: var(--muted); margin: 0; }
+
+/* ── Lists ───────────────────────────────────────────────────────────── */
+.w-list { margin: 0; padding-left: 20px; }
+.w-list li { margin: 6px 0; }
+
+/* ── Cheatsheet ──────────────────────────────────────────────────────── */
+.w-sheet { display: grid; gap: 8px; }
+.w-row { display: grid; grid-template-columns: 130px 1fr; gap: 14px; align-items: baseline; padding: 4px 0; }
+.w-row--off { opacity: .45; }
+.w-keys {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px; font-weight: 600; color: var(--accent);
+  background: var(--elevated); border: 1px solid var(--border);
+  border-radius: 7px; padding: 3px 8px; text-align: center; white-space: nowrap;
+}
+.w-label { color: var(--text); }
+.w-badge {
+  font-size: 11px; color: var(--muted); border: 1px solid var(--border);
+  border-radius: 6px; padding: 1px 6px; margin-left: 8px;
+}
+
+/* ── Privacy ─────────────────────────────────────────────────────────── */
+.w-privacy { border-color: var(--good); }
+.w-privacy .w-card__heading::before { content: "🔒 "; }
+
+/* ── Footer ──────────────────────────────────────────────────────────── */
+.w-footer { text-align: center; color: var(--muted); font-size: 14px; margin-top: 28px; }
+.w-footer a { color: var(--accent); text-decoration: none; }
+.w-footer a:hover { text-decoration: underline; }
+.w-footer__links { margin-top: 10px; display: flex; gap: 18px; justify-content: center; flex-wrap: wrap; }
+
+/* ── Animated demos (Silo D — mount target; populated by demos.ts) ───── */
+.w-demos { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.w-demo {
+  background: var(--elevated); border: 1px solid var(--border);
+  border-radius: 12px; padding: 16px; overflow: hidden;
+}
+.w-demo__title { font-weight: 600; font-size: 14px; margin: 0 0 10px; }
+.w-demo__stage {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px; color: var(--text); min-height: 44px;
+}
+.w-demo__caret { color: var(--accent); animation: w-blink 1s step-end infinite; }
+
+@keyframes w-blink { 50% { opacity: 0; } }
+@keyframes w-type-fade { from { opacity: .25; } to { opacity: 1; } }
+@keyframes w-slide-in { from { transform: translateY(6px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .w-demo__caret { animation: none; }
+  .w-btn { transition: none; }
+}
+
+@media (max-width: 540px) {
+  .w-row { grid-template-columns: 100px 1fr; }
+  .w-hero__title { font-size: 26px; }
+}

--- a/src/welcome/welcome.css
+++ b/src/welcome/welcome.css
@@ -91,12 +91,16 @@ body {
   background: var(--elevated); border: 1px solid var(--border);
   border-radius: 12px; padding: 16px; overflow: hidden;
 }
+.w-demo { animation: w-slide-in .4s ease both; }
 .w-demo__title { font-weight: 600; font-size: 14px; margin: 0 0 10px; }
 .w-demo__stage {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 13px; color: var(--text); min-height: 44px;
+  font-size: 13px; color: var(--text); min-height: 32px;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px;
+  animation: w-type-fade 1.2s ease both;
 }
 .w-demo__caret { color: var(--accent); animation: w-blink 1s step-end infinite; }
+.w-demo__caption { font-size: 12px; color: var(--muted); margin: 10px 0 0; }
 
 @keyframes w-blink { 50% { opacity: 0; } }
 @keyframes w-type-fade { from { opacity: .25; } to { opacity: 1; } }

--- a/src/welcome/welcome.html
+++ b/src/welcome/welcome.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Welcome to SmrutiCortex</title>
+  <link rel="icon" type="image/svg+xml" href="../assets/icon-48.svg" />
+  <link rel="stylesheet" href="welcome.css" />
+  <style>
+    /* Critical CSS — inlined so the page has its dark background before welcome.css loads */
+    :root{color-scheme:light dark}
+    html,body{margin:0;padding:0;background:#0d1117;color:#e6edf3;
+      font-family:Inter,system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial}
+    #welcome-root{max-width:860px;margin:0 auto;padding:32px 20px 64px}
+  </style>
+</head>
+<body>
+  <main id="welcome-root" aria-busy="true">
+    <!-- Rendered by welcome.js from welcome-content.ts (single source of copy). -->
+  </main>
+  <script src="welcome.js"></script>
+</body>
+</html>

--- a/src/welcome/welcome.ts
+++ b/src/welcome/welcome.ts
@@ -1,0 +1,162 @@
+// welcome.ts — esbuild entrypoint for the welcome / onboarding page.
+//
+// Thin imperative shell: reads settings, renders the (testable) content model from
+// welcome-content.ts into the DOM, and wires the two CTAs. All copy lives in
+// welcome-content.ts; all reference data lives in shared/onboarding/cheatsheet.ts.
+
+import { Logger, errorMeta } from '../core/logger';
+import { SettingsManager } from '../core/settings';
+import { getWelcomePageModel, type WelcomePageModel } from './welcome-content';
+import type { CheatsheetSection } from '../shared/onboarding/cheatsheet';
+
+const log = Logger.forComponent('Welcome');
+
+/** Storage flag read by popup.ts on open to replay the spotlight tour. */
+const REPLAY_TOUR_KEY = 'replayTourOnNextOpen';
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  opts: { className?: string; text?: string; html?: never } = {},
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (opts.className) { node.className = opts.className; }
+  if (opts.text != null) { node.textContent = opts.text; }
+  return node;
+}
+
+function renderCheatsheet(section: CheatsheetSection): HTMLElement {
+  const card = el('section', { className: 'w-card' });
+  card.appendChild(el('h2', { className: 'w-card__heading', text: section.title }));
+  const sheet = el('div', { className: 'w-sheet' });
+  for (const entry of section.entries) {
+    const row = el('div', { className: entry.enabled === false ? 'w-row w-row--off' : 'w-row' });
+    row.appendChild(el('span', { className: 'w-keys', text: entry.keys }));
+    const label = el('span', { className: 'w-label', text: entry.label });
+    if (entry.advanced) { label.appendChild(el('span', { className: 'w-badge', text: 'advanced' })); }
+    if (entry.enabled === false) { label.appendChild(el('span', { className: 'w-badge', text: 'off' })); }
+    row.appendChild(label);
+    sheet.appendChild(row);
+  }
+  card.appendChild(sheet);
+  return card;
+}
+
+function render(model: WelcomePageModel): void {
+  const root = document.getElementById('welcome-root');
+  if (!root) { return; }
+  root.replaceChildren();
+
+  // Hero
+  const hero = el('header', { className: 'w-hero' });
+  hero.appendChild(el('div', { className: 'w-hero__emoji', text: model.hero.emoji }));
+  hero.appendChild(el('h1', { className: 'w-hero__title', text: model.hero.title }));
+  hero.appendChild(el('p', { className: 'w-hero__tagline', text: model.hero.tagline }));
+  hero.appendChild(el('p', { className: 'w-hero__blurb', text: model.hero.blurb }));
+
+  // CTAs
+  const cta = el('div', { className: 'w-cta' });
+  const tryBtn = el('button', { className: 'w-btn w-btn--primary', text: 'Try it now' });
+  tryBtn.id = 'w-try';
+  const tourBtn = el('button', { className: 'w-btn', text: 'Replay the 30-second tour' });
+  tourBtn.id = 'w-replay-tour';
+  cta.append(tryBtn, tourBtn);
+  const hint = el('p', { className: 'w-cta__hint' });
+  hint.id = 'w-cta-hint';
+  hero.append(cta, hint);
+  root.appendChild(hero);
+
+  // The one big tip
+  const tip = el('section', { className: 'w-card w-bigtip' });
+  tip.appendChild(el('h2', { className: 'w-card__heading', text: model.bigTip.heading }));
+  tip.appendChild(el('div', { className: 'w-bigtip__keys', text: model.bigTip.keys }));
+  tip.appendChild(el('p', { className: 'w-bigtip__text', text: model.bigTip.text }));
+  root.appendChild(tip);
+
+  // Three ways to open
+  const ways = el('section', { className: 'w-card' });
+  ways.appendChild(el('h2', { className: 'w-card__heading', text: model.openWays.heading }));
+  const waysList = el('ol', { className: 'w-list' });
+  for (const w of model.openWays.ways) { waysList.appendChild(el('li', { text: w })); }
+  ways.appendChild(waysList);
+  root.appendChild(ways);
+
+  // Cheatsheet sections
+  for (const section of model.cheatsheet) { root.appendChild(renderCheatsheet(section)); }
+
+  // Demos mount point (filled by Silo D in a later phase; empty/ignored if absent)
+  const demos = el('section', { className: 'w-card' });
+  demos.id = 'w-demos-card';
+  demos.hidden = true;
+  root.appendChild(demos);
+
+  // Privacy
+  const privacy = el('section', { className: 'w-card w-privacy' });
+  privacy.appendChild(el('h2', { className: 'w-card__heading', text: model.privacy.heading }));
+  const privacyList = el('ul', { className: 'w-list' });
+  for (const line of model.privacy.lines) { privacyList.appendChild(el('li', { text: line })); }
+  privacy.appendChild(privacyList);
+  root.appendChild(privacy);
+
+  // Footer
+  const footer = el('footer', { className: 'w-footer' });
+  footer.appendChild(el('p', { text: model.footer.replayNote }));
+  const links = el('div', { className: 'w-footer__links' });
+  const guide = el('a', { text: model.footer.onlineGuideLabel });
+  guide.href = model.footer.onlineGuideUrl; guide.target = '_blank'; guide.rel = 'noopener';
+  const priv = el('a', { text: model.footer.privacyLabel });
+  priv.href = model.footer.privacyUrl; priv.target = '_blank'; priv.rel = 'noopener';
+  links.append(guide, priv);
+  footer.appendChild(links);
+  root.appendChild(footer);
+
+  root.removeAttribute('aria-busy');
+}
+
+/** Open the toolbar popup if the browser allows it; otherwise show a plain hint. */
+async function openPopupOrHint(fallback: string): Promise<void> {
+  const hint = document.getElementById('w-cta-hint');
+  try {
+    const openPopup = (chrome.action as { openPopup?: () => Promise<void> } | undefined)?.openPopup;
+    if (!openPopup) { throw new Error('openPopup unavailable'); }
+    await openPopup.call(chrome.action);
+  } catch {
+    if (hint) { hint.textContent = fallback; }
+  }
+}
+
+function setReplayTourFlag(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    try {
+      chrome.storage.local.set({ [REPLAY_TOUR_KEY]: true }, () => resolve());
+    } catch {
+      resolve();
+    }
+  });
+}
+
+function wireCtas(): void {
+  document.getElementById('w-try')?.addEventListener('click', () => {
+    void openPopupOrHint('Click the SmrutiCortex icon in your toolbar, or press Ctrl+Shift+S on any page.');
+  });
+  document.getElementById('w-replay-tour')?.addEventListener('click', () => {
+    void (async () => {
+      await setReplayTourFlag();
+      await openPopupOrHint('Open the popup (toolbar icon) to see the tour — it will start automatically.');
+    })();
+  });
+}
+
+async function main(): Promise<void> {
+  let enabledModes: string[] | undefined;
+  try {
+    await SettingsManager.init();
+    const modes = SettingsManager.getSetting('commandPaletteModes');
+    if (Array.isArray(modes)) { enabledModes = modes; }
+  } catch (err) {
+    log.warn('main', 'Could not load settings; showing all modes as enabled', errorMeta(err));
+  }
+  render(getWelcomePageModel(enabledModes));
+  wireCtas();
+}
+
+void main();

--- a/src/welcome/welcome.ts
+++ b/src/welcome/welcome.ts
@@ -21,7 +21,7 @@ function el<K extends keyof HTMLElementTagNameMap>(
 ): HTMLElementTagNameMap[K] {
   const node = document.createElement(tag);
   if (opts.className) { node.className = opts.className; }
-  if (opts.text != null) { node.textContent = opts.text; }
+  if (opts.text !== undefined) { node.textContent = opts.text; }
   return node;
 }
 

--- a/src/welcome/welcome.ts
+++ b/src/welcome/welcome.ts
@@ -8,6 +8,7 @@ import { Logger, errorMeta } from '../core/logger';
 import { SettingsManager } from '../core/settings';
 import { getWelcomePageModel, type WelcomePageModel } from './welcome-content';
 import type { CheatsheetSection } from '../shared/onboarding/cheatsheet';
+import { mountDemos } from '../shared/onboarding/demos';
 
 const log = Logger.forComponent('Welcome');
 
@@ -83,10 +84,11 @@ function render(model: WelcomePageModel): void {
   // Cheatsheet sections
   for (const section of model.cheatsheet) { root.appendChild(renderCheatsheet(section)); }
 
-  // Demos mount point (filled by Silo D in a later phase; empty/ignored if absent)
+  // Demos mount point (Silo D) — heading now; the grid is mounted in main() when enabled.
   const demos = el('section', { className: 'w-card' });
   demos.id = 'w-demos-card';
   demos.hidden = true;
+  demos.appendChild(el('h2', { className: 'w-card__heading', text: 'See it in action' }));
   root.appendChild(demos);
 
   // Privacy
@@ -148,15 +150,25 @@ function wireCtas(): void {
 
 async function main(): Promise<void> {
   let enabledModes: string[] | undefined;
+  let demosEnabled = true;
   try {
     await SettingsManager.init();
     const modes = SettingsManager.getSetting('commandPaletteModes');
     if (Array.isArray(modes)) { enabledModes = modes; }
+    demosEnabled =
+      SettingsManager.getSetting('onboardingEnabled') !== false &&
+      SettingsManager.getSetting('onboardingDemosEnabled') !== false;
   } catch (err) {
     log.warn('main', 'Could not load settings; showing all modes as enabled', errorMeta(err));
   }
   render(getWelcomePageModel(enabledModes));
   wireCtas();
+
+  const demosCard = document.getElementById('w-demos-card');
+  if (demosCard) {
+    const mounted = mountDemos(demosCard, { enabled: demosEnabled });
+    demosCard.hidden = !mounted;
+  }
 }
 
 void main();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
         'src/__test-utils__/**',
         'src/popup/popup.ts',                // monolithic UI IIFE, no exports
         'src/content_scripts/quick-search.ts', // Shadow DOM IIFE, no exports
+        'src/welcome/welcome.ts',             // welcome-page DOM entry IIFE (logic lives in welcome-content.ts)
         'src/core/scorer-types.ts',           // type definitions only
         'src/background/schema.ts',           // type definitions only
       ],


### PR DESCRIPTION
## Why
New users couldn't figure out how to use the extension or discover its power
features — hurting adoption. The gap wasn't missing features or docs; it was the
missing in-product bridge from "just installed" to "knows the power."

## What
**Education**
- Replayable **welcome page** (`src/welcome/`) — auto-opens on install, reopenable
  anytime via 👋 button, `welcome` palette command, or tour-replay.
- Four **independently toggleable** teaching silos (`src/shared/onboarding/`):
  checklist · replayable tips (fixes the "shown once, lost forever" latch) ·
  rich `?` cheatsheet (overlay + popup) · animated demos. Master kill-switch +
  per-silo flags.

**Safety / foolproofing**
- In-popup confirm + **10s Undo** on Clear & Factory Reset (EXPORT→IMPORT
  snapshot), with "export a backup first".
- **Reset to Safe Defaults** button.
- `>` power-tier warnings in both surfaces.

**Spring-Boot-style auto-config**
- `src/core/fresh-install-profile.ts` — one heavily-commented place to tune the
  out-of-box experience. Safe high-value features ON; dangerous/heavy features
  opt-in. Applies to **fresh installs only** — existing users untouched.

## Notes
- **No manifest/permission changes** (welcome page is an internal `tabs.create`).
- 12 atomic commits · **2,688 unit tests passing** · coverage 94% lines (ratchet OK).
- E2E specs (`welcome.spec.ts`, `safety-undo.spec.ts`) deferred as follow-up.
